### PR TITLE
Allow the EnvironmentConfigSource to only load env vars that have a p…

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,17 +248,17 @@ You can add several ConfigSources to the builder and Gestalt, they will be loade
 ```
 In the above example we first load a file devFile then overwrite any values from the Environment Variables. 
 
-| Config Source | Details |
-| --------------- | ------- | 
-| ClassPathConfigSource | Load a file from the java class path. Uses getResourceAsStream to find and load the InputStream. |
-| EnvironmentConfigSource | Loads all Environment Variables in the system, will convert them to a list of key values from the Env Map for the config loader. |
-| FileConfigSource | Loads a file from the local file system. The format for the source will depend on the file extension of the file. For example if it is dev.properties, the format will be properties. Returns a InpuStream for the config loader.  |
-| GitConfigSource | Syncs a remote repo locally then uses the files to build a configuration. This uses jgit and supports several forms of authentication. See GitConfigSourceTest.java for examples of use. |
-| MapConfigSource | Allows you to pass in your own map, it will convert the map into a list of path and value for the config loader. |
-| StringConfigSource | Takes any string and converts it into a InputStream. You must also provide the format type so we can match it to a loader. |
-| SystemPropertiesConfigSource | Loads the Java System Properties and convert them to a list of key values or the config loader. |
-| S3ConfigSource | Loads a config source from AWS S3, Must include package com.github.gestalt-config:gestalt-s3:version. |
-| URLConfigSource | Loads a config source from a URL. |
+| Config Source | Details                                                                                                                                                                                                                                                            |
+| --------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
+| ClassPathConfigSource | Load a file from the java class path. Uses getResourceAsStream to find and load the InputStream.                                                                                                                                                                   |
+| EnvironmentConfigSource | Loads all Environment Variables in the system, will convert them to a list of key values from the Env Map for the config loader. You can provide a prefix to only load Environment Variables with the prefix. Then you can choose to keep the prefix or remove it. |
+| FileConfigSource | Loads a file from the local file system. The format for the source will depend on the file extension of the file. For example if it is dev.properties, the format will be properties. Returns a InpuStream for the config loader.                                  |
+| GitConfigSource | Syncs a remote repo locally then uses the files to build a configuration. This uses jgit and supports several forms of authentication. See GitConfigSourceTest.java for examples of use.                                                                           |
+| MapConfigSource | Allows you to pass in your own map, it will convert the map into a list of path and value for the config loader.                                                                                                                                                   |
+| StringConfigSource | Takes any string and converts it into a InputStream. You must also provide the format type so we can match it to a loader.                                                                                                                                         |
+| SystemPropertiesConfigSource | Loads the Java System Properties and convert them to a list of key values or the config loader.                                                                                                                                                                    |
+| S3ConfigSource | Loads a config source from AWS S3, Must include package com.github.gestalt-config:gestalt-s3:version.                                                                                                                                                              |
+| URLConfigSource | Loads a config source from a URL.                                                                                                                                                                                                                                  |
 
 # Config Loader
 Each config loader understands how to load a specific type of config. Often this is associated with a specific ConfigSource. For example the EnvironmentVarsLoader only loads the EnvironmentConfigSource. However, some loaders expect a format of the config, but accept it from multiple sources. For example the PropertyLoader expects the typical java property file, but it can come from any source as long as it is an input stream. It may be the system properties, local file, github, or S3.   

--- a/README.md
+++ b/README.md
@@ -230,11 +230,12 @@ Using the extension functions you don't need to specify the type if the return t
   val pool: HttpPool = gestalt.getConfig("http.pool")
   val hosts: List<Host> = gestalt.getConfig("db.hosts", emptyList())
 ```
-| Gestalt Version | Kotlin Version |
-| --------------- | ------- | 
-| 0.10.0 + | 1.6 |
-| 0.9.0 to 0.9.3 | 1.5 |
-| 0.1.0 to 0.8.1 | 1.4 |
+| Gestalt Version  | Kotlin Version |
+|------------------|----------------| 
+| 0.13.0 +         | 1.7            |
+| 0.10.0 to 0.12.0 | 1.6            |
+| 0.9.0 to 0.9.3   | 1.5            |
+| 0.1.0 to 0.8.1   | 1.4            |
 
 # Config Sources
 Adding a ConfigSource to the builder is the minimum step needed to build the Gestalt Library. 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,5 +8,5 @@ plugins {
 
 allprojects {
     group = "com.github.gestalt-config"
-    version = "0.12.0"
+    version = "0.13.0"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.6.21"
+    kotlin("jvm") version "1.7.10"
     // Support convention plugins written in Kotlin. Convention plugins are build scripts in 'src/main' that automatically become available as plugins in the main build.
     `kotlin-dsl`
 }
@@ -20,8 +20,8 @@ dependencies {
     implementation("com.palantir.gradle.gitversion:gradle-git-version:0.15.0")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:2.0.2")
 
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.6.21")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.7.10")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.20.0")
 }
 

--- a/buildSrc/src/main/kotlin/gestalt.kotlin-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/gestalt.kotlin-common-conventions.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
 
     // Will apply the plugin to all dokka tasks
-    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.6.21")
+    dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.7.10")
 }
 
 tasks.dokkaJavadoc.configure {

--- a/buildSrc/src/main/kotlin/org/github/gestalt/config/Dependancies.kt
+++ b/buildSrc/src/main/kotlin/org/github/gestalt/config/Dependancies.kt
@@ -8,15 +8,15 @@ object Application {
     object Versions {
         const val slf4j = "1.7.36"
 
-        const val kotlinVersion = "1.6.21"
-        const val kodeinDIVersion = "7.11.0"
+        const val kotlinVersion = "1.7.10"
+        const val kodeinDIVersion = "7.13.1"
         const val koinDIVersion = "3.2.0"
 
         const val jackson = "2.13.3"
 
         const val hocon = "1.4.2"
-        const val aws = "2.17.201"
-        const val jgit = "6.1.0.202203080745-r"
+        const val aws = "2.17.233"
+        const val jgit = "6.2.0.202206071550-r"
 
         const val eddsa = "0.3.0"
 
@@ -63,18 +63,18 @@ object Application {
 object Test {
     private object Versions {
         const val junit5 = "5.8.2"
-        const val assertJ = "3.22.0"
-        const val mockito = "4.6.0"
+        const val assertJ = "3.23.1"
+        const val mockito = "4.6.1"
         const val mockk = "1.12.4"
-        const val kotlinTestAssertions = "5.3.0"
-        const val awsMock = "2.4.10"
+        const val kotlinTestAssertions = "5.3.2"
+        const val awsMock = "2.4.13"
     }
 
     const val junitAPI = "org.junit.jupiter:junit-jupiter-api:${Versions.junit5}"
     const val junitEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junit5}"
     const val assertJ = "org.assertj:assertj-core:${Versions.assertJ}"
 
-    const val mockito = "org.mockito:mockito-core:${Versions.mockito}"
+    const val mockito = "org.mockito:mockito-inline:${Versions.mockito}"
 
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val kotlinTestAssertions = "io.kotest:kotest-assertions-core-jvm:${Versions.kotlinTestAssertions}"

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/SystemWrapper.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/SystemWrapper.java
@@ -1,0 +1,14 @@
+package org.github.gestalt.config.utils;
+
+import java.util.Map;
+
+public final class SystemWrapper {
+
+    private SystemWrapper() {
+
+    }
+
+    public static Map<String, String> getEnvVars() {
+        return System.getenv();
+    }
+}

--- a/gestalt-sample-java-latest/build.gradle.kts
+++ b/gestalt-sample-java-latest/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.compileTestJava {
 }
 
 dependencies {
-    val gestaltVersion = "0.12.0"
+    val gestaltVersion = "0.13.0"
     testImplementation("com.github.gestalt-config:gestalt-core:$gestaltVersion")
     testImplementation("com.github.gestalt-config:gestalt-hocon:$gestaltVersion")
     testImplementation("com.github.gestalt-config:gestalt-kotlin:$gestaltVersion")

--- a/gestalt-sample/build.gradle.kts
+++ b/gestalt-sample/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    val gestaltVersion = "0.12.0"
+    val gestaltVersion = "0.13.0"
     testImplementation("com.github.gestalt-config:gestalt-core:$gestaltVersion")
     testImplementation("com.github.gestalt-config:gestalt-hocon:$gestaltVersion")
     testImplementation("com.github.gestalt-config:gestalt-kotlin:$gestaltVersion")

--- a/gradle/libs.versions.toml.bak
+++ b/gradle/libs.versions.toml.bak
@@ -1,5 +1,5 @@
 [versions]
-kotlinVersion = "1.6.21"
+kotlinVersion = "1.7.10"
 kodeinDIVersion = "7.11.0"
 koinDIVersion = "3.2.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Allow the EnvironmentConfigSource to only load env vars that have a prefix. Then we can either keep or remove the prefix.
Upgrade to Kotlin 1.7.10
Update dependencies.