### PR TITLE
When using the PropertyLoader ensure the input stream has been closed.

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public abstract class SentenceLexer {
 
     /**
-     * Return the deliminator
+     * Return the deliminator.
      *
      * @return the deliminator
      */

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
@@ -14,6 +14,7 @@ import org.github.gestalt.config.utils.Pair;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -71,8 +72,8 @@ public class PropertyLoader implements ConfigLoader {
     public ValidateOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
         Properties properties = new Properties();
         if (source.hasStream()) {
-            try {
-                properties.load(source.loadStream());
+            try (InputStream is = source.loadStream()) {
+                properties.load(is);
             } catch (IOException | NullPointerException e) {
                 throw new GestaltException("Exception loading source: " + source.name(), e);
             }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSource.java
@@ -51,9 +51,13 @@ public class ClassPathConfigSource implements ConfigSource {
 
     @Override
     public InputStream loadStream() throws GestaltException {
-        InputStream is = ClassPathConfigSource.class.getResourceAsStream(resource);
+
+        InputStream is = getClass().getClassLoader().getResourceAsStream(resource);
         if (is == null) {
-            throw new GestaltException("Unable to load classpath resource from " + resource);
+            is = ClassPathConfigSource.class.getResourceAsStream(resource);
+            if (is == null) {
+                throw new GestaltException("Unable to load classpath resource from " + resource);
+            }
         }
         return is;
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/source/ClassPathConfigSourceTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/source/ClassPathConfigSourceTest.java
@@ -16,6 +16,14 @@ class ClassPathConfigSourceTest {
     }
 
     @Test
+    void loadFileWithoutSlash() throws GestaltException {
+        ClassPathConfigSource classPathConfigSource = new ClassPathConfigSource("test.properties");
+
+        Assertions.assertTrue(classPathConfigSource.hasStream());
+        Assertions.assertNotNull(classPathConfigSource.loadStream());
+    }
+
+    @Test
     void loadFileNull() {
         GestaltException exception = Assertions.assertThrows(GestaltException.class, () -> new ClassPathConfigSource(null));
 
@@ -50,6 +58,7 @@ class ClassPathConfigSourceTest {
 
         Assertions.assertEquals("Class Path resource: /test.properties", classPathConfigSource.name());
     }
+
 
 
     @Test


### PR DESCRIPTION
For the ClasspathConfigSource, first check the class loader for the resource then the class itself. Addresses https://github.com/gestalt-config/gestalt/issues/62