### PR TITLE
You can provide a default for the substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,14 @@ You can specify the substitution in the format ${transform:key} or ${key}. If yo
 Unlike the rest of Gestalt, this is case-sensitive, and it does not tokenize the string (except the node transform). The key expects an exact match, so if the Environment Variable name is DB_USER you need to use the key DB_USER, db.user or db_user will not match.
 
 ```properties
-db.uri=jdbc:mysql://${env:DB_HOST}:${map:DB_PORT}/${sys:environment}
+db.uri=jdbc:mysql://${DB_HOST}:${map:DB_PORT}/${sys:environment}
+```
+
+### Defaults for a Substitution
+You can provide a default for the substitution in the format ${transform:key:=default} or ${key:=default}. If you provide a default it will use the default value in the event that the key provided cant be found
+
+```properties
+db.uri=jdbc:mysql://${DB_HOST}:${map:DB_PORT:=3306}/${environment:=dev}
 ```
 
 ### Escaping a Substitution

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
     group = "com.github.gestalt-config"
-    version = "0.20.4"
+    version = "0.20.5"
 }
 
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
@@ -84,6 +84,10 @@ public class GestaltBuilder {
     // the maximum nested substitution depth.
     private Integer maxSubstitutionNestedDepth = null;
 
+    // the regex used to parse string substitutions.
+    // Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+    private String substitutionRegex = null;
+
     /**
      * Adds all default decoders to the builder. Uses the ServiceLoader to find all registered Decoders and adds them
      *
@@ -613,6 +617,26 @@ public class GestaltBuilder {
         this.maxSubstitutionNestedDepth = maxSubstitutionNestedDepth;
     }
 
+    /**
+     * the regex used to parse string substitutions.
+     * Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+     *
+     * @return the string substitution regex
+     */
+    public String getSubstitutionRegex() {
+        return substitutionRegex;
+    }
+
+    /**
+     * the regex used to parse string substitutions.
+     * Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+     *
+     * @param substitutionRegex the string substitution regex
+     */
+    public void setSubstitutionRegex(String substitutionRegex) {
+        this.substitutionRegex = substitutionRegex;
+    }
+
 
     /**
      * dedupe decoders and return the deduped list.
@@ -766,6 +790,9 @@ public class GestaltBuilder {
 
         newConfig.setMaxSubstitutionNestedDepth(Objects.requireNonNullElseGet(maxSubstitutionNestedDepth,
             () -> gestaltConfig.getMaxSubstitutionNestedDepth()));
+
+        newConfig.setSubstitutionRegex(Objects.requireNonNullElseGet(substitutionRegex,
+            () -> gestaltConfig.getSubstitutionRegex()));
 
         return newConfig;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
@@ -35,6 +35,11 @@ public class GestaltConfig {
     // the maximum nested substitution depth.
     private int maxSubstitutionNestedDepth = 5;
 
+    // the regex used to parse string substitutions.
+    // Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+    private String substitutionRegex =
+        "((?<transform>\\w+):)?(?<key>[\\w ,_.+;\"'`~!@#$%^&*()\\[\\]<>]+)(:=(?<default>[\\w ,_.+;:\"'`~!@#$%^&*()\\[\\]<>]+))?";
+
     /**
      * Treat all warnings as errors.
      *
@@ -215,5 +220,26 @@ public class GestaltConfig {
      */
     public void setMaxSubstitutionNestedDepth(int maxSubstitutionNestedDepth) {
         this.maxSubstitutionNestedDepth = maxSubstitutionNestedDepth;
+    }
+
+
+    /**
+     * the regex used to parse string substitutions.
+     * Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+     *
+     * @return the string substitution regex
+     */
+    public String getSubstitutionRegex() {
+        return substitutionRegex;
+    }
+
+    /**
+     * the regex used to parse string substitutions.
+     * Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
+     *
+     * @param substitutionRegex the string substitution regex
+     */
+    public void setSubstitutionRegex(String substitutionRegex) {
+        this.substitutionRegex = substitutionRegex;
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
@@ -1,5 +1,7 @@
 package org.github.gestalt.config.entity;
 
+import org.github.gestalt.config.post.process.transform.TransformerPostProcessor;
+
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -37,8 +39,7 @@ public class GestaltConfig {
 
     // the regex used to parse string substitutions.
     // Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
-    private String substitutionRegex =
-        "((?<transform>\\w+):)?(?<key>[\\w ,_.+;\"'`~!@#$%^&*()\\[\\]<>]+)(:=(?<default>[\\w ,_.+;:\"'`~!@#$%^&*()\\[\\]<>]+))?";
+    private String substitutionRegex = TransformerPostProcessor.defaultSubstitutionRegex;
 
     /**
      * Treat all warnings as errors.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
@@ -1116,6 +1116,25 @@ public abstract class ValidationError {
     }
 
     /**
+     * Transform doesnt match the regex
+     */
+    public static class TransformDoesntMatchRegex extends ValidationError {
+        private final String path;
+        private final String value;
+
+        public TransformDoesntMatchRegex(String path, String value) {
+            super(ValidationLevel.ERROR);
+            this.path = path;
+            this.value = value;
+        }
+
+        @Override
+        public String description() {
+            return "Transform doesnt match the expected format with value " + value + " on path " + path;
+        }
+    }
+
+    /**
      * Not a valid SubstitutionNode
      */
     public static class NotAValidSubstitutionNode extends ValidationError {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessor.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessor.java
@@ -33,8 +33,8 @@ import static org.github.gestalt.config.utils.CollectionUtils.buildOrderedConfig
  */
 public class TransformerPostProcessor implements PostProcessor {
 
-    private static final String regexPattern =
-        "((?<transform>\\w+):)?(?<key>[\\w ,_.+;\"'`~!@#$%^&*()\\[\\]<>]+)(:=(?<default>[\\w ,_.+;:\"'`~!@#$%^&*()\\[\\]<>]+))?";
+    public static final String defaultSubstitutionRegex =
+        "^((?<transform>\\w+):)?(?<key>[\\w ,_.+;\"'`~!@#$%^&*()\\[\\]<>]+)(:=(?<default>[\\w ,_.+;:\"'`~!@#$%^&*()\\[\\]<>]+))?$";
     private Pattern pattern;
 
     private final Map<String, Transformer> transformers;
@@ -56,7 +56,7 @@ public class TransformerPostProcessor implements PostProcessor {
         });
 
         this.orderedDefaultTransformers = buildOrderedConfigPriorities(transformersList, false);
-        this.pattern = Pattern.compile(regexPattern);
+        this.pattern = Pattern.compile(defaultSubstitutionRegex);
     }
 
     /**
@@ -74,7 +74,7 @@ public class TransformerPostProcessor implements PostProcessor {
         }
 
         this.substitutionTreeBuilder = new SubstitutionTreeBuilder("${", "}");
-        this.pattern = Pattern.compile(regexPattern);
+        this.pattern = Pattern.compile(defaultSubstitutionRegex);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class TransformerPostProcessor implements PostProcessor {
             config.getConfig().getSubstitutionClosingToken());
 
         this.maxRecursionDepth = config.getConfig().getMaxSubstitutionNestedDepth();
-        this.pattern = Pattern.compile(regexPattern);
+        this.pattern = Pattern.compile(defaultSubstitutionRegex);
     }
 
     @Override
@@ -207,7 +207,7 @@ public class TransformerPostProcessor implements PostProcessor {
         if (foundMatch) {
             return ValidateOf.valid(newLeafValue.toString());
         } else {
-            return ValidateOf.valid(input);
+            return ValidateOf.inValid(new ValidationError.TransformDoesntMatchRegex(path, input));
         }
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessorTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessorTest.java
@@ -98,6 +98,45 @@ class TransformerPostProcessorTest {
     }
 
     @Test
+    void processTextWithMultipleDefaultsButHasValues() {
+
+        Map<String, String> customMap = new HashMap<>();
+        customMap.put("place", "world");
+        customMap.put("weather", "sunny");
+        CustomMapTransformer transformer = new CustomMapTransformer(customMap);
+
+        TransformerPostProcessor transformerPostProcessor = new TransformerPostProcessor(Collections.singletonList(transformer));
+        LeafNode node = new LeafNode("hello ${map:place:=earth} it is ${weather:=overcast} today");
+        ValidateOf<ConfigNode> validateNode = transformerPostProcessor.process("location", node);
+
+        Assertions.assertFalse(validateNode.hasErrors());
+        Assertions.assertTrue(validateNode.hasResults());
+        Assertions.assertTrue(validateNode.results().getValue().isPresent());
+        Assertions.assertEquals("hello world it is sunny today", validateNode.results().getValue().get());
+    }
+
+    @Test
+    void processInvalidFormat() {
+        // not sure about this test, this isnt "intended" behaviour. It just happens to happen.
+
+        Map<String, String> customMap = new HashMap<>();
+        customMap.put("place", "world");
+        customMap.put("weather", "sunny");
+        CustomMapTransformer transformer = new CustomMapTransformer(customMap);
+
+        TransformerPostProcessor transformerPostProcessor = new TransformerPostProcessor(Collections.singletonList(transformer));
+        LeafNode node = new LeafNode("${map:place:world}");
+        ValidateOf<ConfigNode> validateNode = transformerPostProcessor.process("location", node);
+
+        Assertions.assertTrue(validateNode.hasErrors());
+        Assertions.assertEquals(1, validateNode.getErrors().size());
+        Assertions.assertEquals("Transform doesnt match the expected format with value map:place:world on path location",
+            validateNode.getErrors().get(0).description());
+        Assertions.assertEquals(ValidationLevel.ERROR, validateNode.getErrors().get(0).level());
+
+    }
+
+    @Test
     void processNoValue() {
         Map<String, String> customMap = new HashMap<>();
         customMap.put("test", "value");

--- a/gestalt-core/src/test/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessorTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessorTest.java
@@ -82,6 +82,22 @@ class TransformerPostProcessorTest {
     }
 
     @Test
+    void processTextWithMultipleDefaults() {
+
+        Map<String, String> customMap = new HashMap<>();
+        CustomMapTransformer transformer = new CustomMapTransformer(customMap);
+
+        TransformerPostProcessor transformerPostProcessor = new TransformerPostProcessor(Collections.singletonList(transformer));
+        LeafNode node = new LeafNode("hello ${map:place:=world} it is ${weather:=sunny} today");
+        ValidateOf<ConfigNode> validateNode = transformerPostProcessor.process("location", node);
+
+        Assertions.assertFalse(validateNode.hasErrors());
+        Assertions.assertTrue(validateNode.hasResults());
+        Assertions.assertTrue(validateNode.results().getValue().isPresent());
+        Assertions.assertEquals("hello world it is sunny today", validateNode.results().getValue().get());
+    }
+
+    @Test
     void processNoValue() {
         Map<String, String> customMap = new HashMap<>();
         customMap.put("test", "value");

--- a/gestalt-core/src/test/resources/defaultPPEnv.properties
+++ b/gestalt-core/src/test/resources/defaultPPEnv.properties
@@ -5,8 +5,8 @@ db.hosts[1].url=jdbc:postgresql://localhost:5432/mydb2
 db.hosts[2].user=credmond
 db.hosts[2].url=jdbc:postgresql://localhost:5432/mydb3
 db.ConnectionTimeout=6000
-db.idleTimeout=${envVar:DB_IDLETIMEOUT}
-db.maxLifetime=60000.0
+db.idleTimeout=${envVar:DB_IDLETIMEOUT:=900}
+db.maxLifetime=${envVar:NO_RESULTS_FOUND:=60000.0}
 http.Pool.maxTotal=100
 http.Pool.maxPerRoute=10
 http.Pool.validateAfterInactivity=6000

--- a/gestalt-examples/gestalt-sample/src/test/resources/defaultPPEnv.properties
+++ b/gestalt-examples/gestalt-sample/src/test/resources/defaultPPEnv.properties
@@ -5,8 +5,8 @@ db.hosts[1].url=jdbc:postgresql://localhost:5432/mydb2
 db.hosts[2].user=credmond
 db.hosts[2].url=jdbc:postgresql://localhost:5432/mydb3
 db.ConnectionTimeout=6000
-db.idleTimeout=${envVar:DB_IDLETIMEOUT}
-db.maxLifetime=60000.0
+db.idleTimeout=${envVar:DB_IDLETIMEOUT:=900}
+db.maxLifetime=${envVar:NO_RESULTS_FOUND:=60000.0}
 http.Pool.maxTotal=100
 http.Pool.maxPerRoute=10
 http.Pool.validateAfterInactivity=6000

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ pmd = "6.54.0"
 jmh = "1.36"
 gradleJmh = "0.7.1"
 
-gestalt = "0.20.4"
+gestalt = "0.20.5"
 
 gradleVersions = "0.46.0"
 gitVersions = "2.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 java = "11"
 javaLatest = "19"
-kotlin = "1.8.20"
+kotlin = "1.8.21"
 kotlinDokka = "1.8.10"
 kodeinDI = "7.20.1"
 koinDI= "3.4.0"
@@ -23,7 +23,7 @@ junit5 = "5.9.2"
 assertJ = "3.24.2"
 mockito = "5.2.0"
 mockk = "1.13.5"
-koTestAssertions = "5.5.5"
+koTestAssertions = "5.6.1"
 awsMock = "2.11.0"
 
 errorprone = "2.18.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinDokka = "1.8.10"
 kodeinDI = "7.20.1"
 koinDI= "3.4.0"
 
-jackson = "2.14.2"
+jackson = "2.15.0"
 
 guice = "5.1.0"
 cdi = "3.0.0"
@@ -14,7 +14,7 @@ weld = "3.1.0.Final"
 weldCore = "4.0.3.Final"
 
 hocon = "1.4.2"
-aws = "2.20.48"
+aws = "2.20.52"
 jgit = "6.5.0.202303070854-r"
 
 eddsa = "0.3.0"
@@ -37,7 +37,7 @@ pmd = "6.54.0"
 jmh = "1.36"
 gradleJmh = "0.7.1"
 
-gestalt = "0.20.3"
+gestalt = "0.20.4"
 
 gradleVersions = "0.46.0"
 gitVersions = "2.0.0"


### PR DESCRIPTION
You can provide a default for the substitution in the format ${transform:key:=default} or ${key:=default}. If you provide a default it will use the default value in the event that the key provided cant be found https://github.com/gestalt-config/gestalt/issues/51