### PR TITLE
Feat/java modules

### DIFF
--- a/buildSrc/src/main/kotlin/gestalt.kotlin-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/gestalt.kotlin-common-conventions.gradle.kts
@@ -34,8 +34,3 @@ tasks.dokkaJavadoc.configure {
 tasks.withType<Javadoc>().configureEach {
     enabled = false
 }
-
-// needed for the java module system to work.  https://github.com/gradle/gradle/issues/17271
-val compileKotlin: KotlinCompile by tasks
-val compileJava: JavaCompile by tasks
-compileKotlin.destinationDirectory.set(compileJava.destinationDirectory)

--- a/config/detekt/config.yml
+++ b/config/detekt/config.yml
@@ -662,8 +662,6 @@ style:
     active: true
   OptionalUnit:
     active: false
-  OptionalWhenBraces:
-    active: false
   PreferToOverPairSyntax:
     active: false
   ProtectedMemberInFinalClass:

--- a/gestalt-aws/build.gradle.kts
+++ b/gestalt-aws/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(platform(libs.aws.bom))
+    api(platform(libs.aws.bom))
     api(libs.aws.s3)
     api(libs.aws.secret)
     api(libs.aws.url.client)
-    implementation(libs.jackson.databind)
+    api(libs.jackson.databind)
     testImplementation(libs.aws.mock)
     testImplementation(libs.testcontainers.junit5)
 }

--- a/gestalt-aws/src/main/java/module-info.java
+++ b/gestalt-aws/src/main/java/module-info.java
@@ -1,13 +1,13 @@
 // Module info definition for gestalt s3 integration
 module org.github.gestalt.aws {
     requires org.github.gestalt.core;
-    requires software.amazon.awssdk.services.s3;
-    requires software.amazon.awssdk.core;
-    requires software.amazon.awssdk.auth;
-    requires software.amazon.awssdk.regions;
-    requires software.amazon.awssdk.services.secretsmanager;
-    requires software.amazon.awssdk.http.urlconnection;
-    requires com.fasterxml.jackson.databind;
+    requires transitive software.amazon.awssdk.services.s3;
+    requires transitive software.amazon.awssdk.core;
+    requires transitive software.amazon.awssdk.auth;
+    requires transitive software.amazon.awssdk.regions;
+    requires transitive software.amazon.awssdk.services.secretsmanager;
+    requires transitive software.amazon.awssdk.http.urlconnection;
+    requires transitive com.fasterxml.jackson.databind;
 
     exports org.github.gestalt.config.aws.config;
     exports org.github.gestalt.config.aws.errors;

--- a/gestalt-aws/src/main/java/module-info.java
+++ b/gestalt-aws/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 // Module info definition for gestalt s3 integration
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.github.gestalt.aws {
     requires org.github.gestalt.core;
     requires transitive software.amazon.awssdk.services.s3;

--- a/gestalt-examples/gestalt-sample-module/src/main/java/module-info.java
+++ b/gestalt-examples/gestalt-sample-module/src/main/java/module-info.java
@@ -1,22 +1,20 @@
 /**
  * Module info definition for gestalt yaml integration
  */
-module org.github.gestalt.sample {
+module org.github.gestalt.config.integration {
     requires org.github.gestalt.core;
     requires org.github.gestalt.guice;
     requires org.github.gestalt.hocon;
     requires org.github.gestalt.json;
     requires org.github.gestalt.yaml;
-    requires org.github.gestalt.kotlin;
+    requires org.github.gestalt.config.kotlin;
 
     requires com.google.guice;
     requires org.junit.jupiter.api;
     requires kotlin.stdlib;
 
     exports org.github.gestalt.config.integration;
-    exports org.github.gestalt.config.kotlin.integration;
 
     //you need to export any data classes you want to use the Object decoder on (since it uses reflection).
-    opens org.github.gestalt.config.integration to org.github.gestalt.core, org.github.gestalt.guice;
-    opens org.github.gestalt.config.kotlin.integration to org.github.gestalt.core, org.github.gestalt.kotlin;
+    opens org.github.gestalt.config.integration to org.github.gestalt.core, org.github.gestalt.guice, org.github.gestalt.config.kotlin;
 }

--- a/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/MainClass.java
+++ b/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/MainClass.java
@@ -1,7 +1,6 @@
 package org.github.gestalt.config.integration;
 
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.kotlin.integration.GestaltKotlinTest;
 
 /**
  * @author Colin Redmond (c) 2023.
@@ -19,11 +18,5 @@ public class MainClass {
         configTest.integrationTestJsonAndYaml();
         configTest.integrationTestHocon();
         configTest.integrationTestToml();
-
-        GestaltKotlinTest kotlinTests = new GestaltKotlinTest();
-        kotlinTests.integrationTest();
-        kotlinTests.integrationTestEnvVars();
-        kotlinTests.integrationTestWithTypeOf();
-
     }
 }

--- a/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/GestaltKotlinTest.kt
+++ b/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/GestaltKotlinTest.kt
@@ -1,4 +1,4 @@
-package org.github.gestalt.config.kotlin.integration
+package org.github.gestalt.config.integration
 
 import org.github.gestalt.config.Gestalt
 import org.github.gestalt.config.annotations.Config

--- a/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/MainClassKt.kt
+++ b/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/MainClassKt.kt
@@ -1,16 +1,14 @@
-package org.github.gestalt.config.kotlin.integration
+package org.github.gestalt.config.integration
 
 import org.github.gestalt.config.exceptions.GestaltException
-import org.github.gestalt.config.integration.GestaltConfigTest
 
 /**
  * @author Colin Redmond (c) 2023.
  */
-object MainClass {
+object MainClassKt {
     @Throws(GestaltException::class)
     @JvmStatic
     fun main(args: Array<String>) {
-
         val kotlinTests = GestaltKotlinTest()
         kotlinTests.integrationTest()
         kotlinTests.integrationTestEnvVars()

--- a/gestalt-examples/gestalt-sample/build.gradle.kts
+++ b/gestalt-examples/gestalt-sample/build.gradle.kts
@@ -38,6 +38,8 @@ testing {
             dependencies {
                 implementation(project(":gestalt-aws"))
                 implementation(project(":gestalt-core"))
+                implementation(project(":gestalt-git"))
+                implementation(project(":gestalt-google-cloud"))
                 implementation(project(":gestalt-hocon"))
                 implementation(project(":gestalt-kotlin"))
                 implementation(project(":gestalt-json"))
@@ -45,23 +47,15 @@ testing {
                 implementation(project(":gestalt-vault"))
                 implementation(project(":gestalt-yaml"))
 
-                implementation(project(":gestalt-google-cloud"))
-
-
                 implementation(project(":gestalt-kodein-di"))
-                implementation(libs.kodein.di)
 
                 implementation(project(":gestalt-koin-di"))
-                implementation(libs.koin.di)
 
                 implementation(libs.aws.mock)
 
 
                 implementation(project(":gestalt-guice"))
-                implementation(libs.guice)
                 implementation(libs.testcontainers.junit5)
-
-                implementation(libs.vault)
             }
         }
     }

--- a/gestalt-git/build.gradle.kts
+++ b/gestalt-git/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.jgit)
-    implementation(libs.jgit.apache.ssh)
-    implementation(libs.eddsa)
+    api(libs.jgit)
+    api(libs.jgit.apache.ssh)
+    api(libs.eddsa)
 }
 

--- a/gestalt-git/src/main/java/module-info.java
+++ b/gestalt-git/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module org.github.gestalt.git {
     requires org.github.gestalt.core;
-    requires org.eclipse.jgit;
+    requires transitive org.eclipse.jgit;
 
     exports org.github.gestalt.config.git;
 }

--- a/gestalt-git/src/main/java/module-info.java
+++ b/gestalt-git/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 /*
  *  Module info definition for gestalt git integration
  */
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.github.gestalt.git {
     requires org.github.gestalt.core;
     requires transitive org.eclipse.jgit;

--- a/gestalt-google-cloud/build.gradle.kts
+++ b/gestalt-google-cloud/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(platform(libs.google.libraries))
-    implementation(libs.google.storage)
-    implementation(libs.google.secret)
+    api(platform(libs.google.libraries))
+    api(libs.google.storage)
+    api(libs.google.secret)
 }
 
 tasks.jar {

--- a/gestalt-guice/build.gradle.kts
+++ b/gestalt-guice/build.gradle.kts
@@ -7,6 +7,6 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.guice)
+    api(libs.guice)
 }
 

--- a/gestalt-guice/src/main/java/module-info.java
+++ b/gestalt-guice/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module org.github.gestalt.guice {
     requires org.github.gestalt.core;
-    requires com.google.guice;
+    requires transitive com.google.guice;
 
     exports org.github.gestalt.config.guice;
 }

--- a/gestalt-guice/src/main/java/module-info.java
+++ b/gestalt-guice/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 /*
  * Module info definition for gestalt hocon integration
  */
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.github.gestalt.guice {
     requires org.github.gestalt.core;
     requires transitive com.google.guice;

--- a/gestalt-hocon/build.gradle.kts
+++ b/gestalt-hocon/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.hocon)
+    api(libs.hocon)
 }

--- a/gestalt-hocon/src/main/java/module-info.java
+++ b/gestalt-hocon/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 /*
  * Module info definition for gestalt hocon integration
  */
+@SuppressWarnings({ "requires-automatic", "requires-transitive-automatic" })
 module org.github.gestalt.hocon {
     requires org.github.gestalt.core;
     requires transitive typesafe.config;

--- a/gestalt-hocon/src/main/java/module-info.java
+++ b/gestalt-hocon/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module org.github.gestalt.hocon {
     requires org.github.gestalt.core;
-    requires typesafe.config;
+    requires transitive typesafe.config;
 
     exports org.github.gestalt.config.hocon;
 

--- a/gestalt-json/build.gradle.kts
+++ b/gestalt-json/build.gradle.kts
@@ -7,6 +7,6 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.bundles.jackson)
+    api(libs.bundles.jackson)
 }
 

--- a/gestalt-json/src/main/java/module-info.java
+++ b/gestalt-json/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module org.github.gestalt.json {
     requires org.github.gestalt.core;
-    requires com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.databind;
 
     exports org.github.gestalt.config.json;
 

--- a/gestalt-kodein-di/build.gradle.kts
+++ b/gestalt-kodein-di/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 dependencies {
     implementation(project(":gestalt-core"))
     implementation(project(":gestalt-kotlin"))
-    implementation(libs.kodein.di)
+    api(libs.kodein.di)
 }
 
 tasks.jar {

--- a/gestalt-koin-di/build.gradle.kts
+++ b/gestalt-koin-di/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 dependencies {
     implementation(project(":gestalt-core"))
     implementation(project(":gestalt-kotlin"))
-    implementation(libs.koin.di)
+    api(libs.koin.di)
 }
 
 tasks.jar {

--- a/gestalt-kotlin/build.gradle.kts
+++ b/gestalt-kotlin/build.gradle.kts
@@ -8,6 +8,13 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.kotlin.reflection)
+    api(libs.kotlin.reflection)
+}
+
+tasks.named("compileJava", JavaCompile::class.java) {
+    options.compilerArgumentProviders.add(CommandLineArgumentProvider {
+        // Provide compiled Kotlin classes to javac – needed for Java/Kotlin mixed sources to work
+        listOf("--patch-module", "org.github.gestalt.config.kotlin=${sourceSets["main"].output.asPath}")
+    })
 }
 

--- a/gestalt-kotlin/src/main/java/module-info.java
+++ b/gestalt-kotlin/src/main/java/module-info.java
@@ -1,9 +1,9 @@
 /**
  * Module info definition for gestalt kotlin integration
  */
-module org.github.gestalt.kotlin {
+module org.github.gestalt.config.kotlin {
     requires org.github.gestalt.core;
-    requires kotlin.reflect;
+    requires transitive kotlin.reflect;
     requires java.base;
 
     exports org.github.gestalt.config.kotlin;

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
@@ -50,6 +50,7 @@ class DataClassDecoder : Decoder<Any> {
         return false
     }
 
+    @Suppress("LongMethod")
     override fun decode(path: String, node: ConfigNode, type: TypeCapture<*>, decoderService: DecoderService): ValidateOf<Any> {
         if (node !is MapNode) {
             return ValidateOf.inValid(ValidationError.DecodingExpectedMapNodeType(path, node))

--- a/gestalt-toml/build.gradle.kts
+++ b/gestalt-toml/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.bundles.jackson)
-    implementation(libs.jackson.toml)
+    api(libs.bundles.jackson)
+    api(libs.jackson.toml)
 }
 
 

--- a/gestalt-toml/src/main/java/module-info.java
+++ b/gestalt-toml/src/main/java/module-info.java
@@ -3,8 +3,8 @@
  */
 module org.github.gestalt.toml {
     requires org.github.gestalt.core;
-    requires com.fasterxml.jackson.databind;
-    requires com.fasterxml.jackson.dataformat.toml;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.dataformat.toml;
 
     exports org.github.gestalt.config.toml;
 

--- a/gestalt-vault/src/main/java/module-info.java
+++ b/gestalt-vault/src/main/java/module-info.java
@@ -3,7 +3,7 @@
  */
 module org.github.gestalt.vault {
     requires org.github.gestalt.core;
-    requires vault.java.driver;
+    requires transitive vault.java.driver;
 
     exports org.github.gestalt.config.vault;
     exports org.github.gestalt.config.vault.config;

--- a/gestalt-yaml/build.gradle.kts
+++ b/gestalt-yaml/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 
 dependencies {
     implementation(project(":gestalt-core"))
-    implementation(libs.bundles.jackson)
-    implementation(libs.jackson.yaml)
+    api(libs.bundles.jackson)
+    api(libs.jackson.yaml)
 }
 
 

--- a/gestalt-yaml/src/main/java/module-info.java
+++ b/gestalt-yaml/src/main/java/module-info.java
@@ -3,8 +3,8 @@
  */
 module org.github.gestalt.yaml {
     requires org.github.gestalt.core;
-    requires com.fasterxml.jackson.databind;
-    requires com.fasterxml.jackson.dataformat.yaml;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.dataformat.yaml;
 
     exports org.github.gestalt.config.yaml;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,10 +19,10 @@ weldCore = "4.0.3.Final"
 jackson = "2.15.2"
 hocon = "1.4.2"
 # Cloud
-awsBom = "2.20.125"
+awsBom = "2.20.129"
 gcpLibraries = "26.22.0"
 # vault
-vault = "6.0.0"
+vault = "6.1.0"
 # Git support
 jgit = "6.6.0.202305301015-r"
 eddsa = "0.3.0"
@@ -30,7 +30,7 @@ eddsa = "0.3.0"
 junit5 = "5.10.0"
 assertJ = "3.24.2"
 mockito = "5.2.0"
-mockk = "1.13.5"
+mockk = "1.13.7"
 koTestAssertions = "5.6.2"
 # @pin last version to support jdk 11
 awsMock = "2.17.0"
@@ -126,7 +126,6 @@ gestalt-toml = { module = "com.github.gestalt-config:gestalt-toml", version.ref 
 gestalt-vault = { module = "com.github.gestalt-config:gestalt-vault", version.ref = "gestalt" }
 gestalt-yaml = { module = "com.github.gestalt-config:gestalt-yaml", version.ref = "gestalt" }
 
-
 [bundles]
 jackson = [
     "jackson-core",
@@ -139,4 +138,3 @@ jackson = [
 [plugins]
 jmh = { id = "me.champeau.jmh", version.ref = "gradleJmh" }
 gradle-ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "gradleVersions" }
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.6.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.7.0")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
fix: changed kotlin jpms to module org.github.gestalt.config.kotlin to align with kotlin docs https://kotlinlang.org/docs/gradle-configure-project.html#configure-with-java-modules-jpms-enabled

fix: expose dependencies as api instead of implementations so you dont need to include sub-dependencies.
fix: made most jpms dependencies transitive.
feat: update to gradle 8.3
feat: add git sample.
update dependencies.