### PR TITLE
feat: change signature of decoder match to canDecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,10 +995,13 @@ You can create your own decoder by implementing the Decoder interface. By return
   /**
  * true if this decoder matches the type capture.
  *
- * @param klass TypeCapture we are looking for a decoder.
+ * @param path           the current path
+ * @param tags           the tags for the current request
+ * @param node           the current node we are decoding.
+ * @param type           the type of object we are decoding.
  * @return true if this decoder matches the type capture
  */
-  boolean matches(TypeCapture<?> klass);
+  boolean canDecode(path: String, tags: Tags, configNode:ConfigNode, TypeCapture<?> klass);
 
   /**
    * Decode the current node. If the current node is a class or list we may need to decode sub nodes.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ArrayDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ArrayDecoder.java
@@ -34,7 +34,7 @@ public final class ArrayDecoder<T> implements Decoder<T[]> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return type.isArray();
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigDecimalDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigDecimalDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -26,8 +27,8 @@ public final class BigDecimalDecoder extends LeafDecoder<BigDecimal> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return BigDecimal.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return BigDecimal.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigIntegerDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigIntegerDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -26,8 +27,8 @@ public final class BigIntegerDecoder extends LeafDecoder<BigInteger> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return BigInteger.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return BigInteger.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BooleanDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BooleanDecoder.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 /**
@@ -22,8 +23,8 @@ public final class BooleanDecoder extends LeafDecoder<Boolean> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Boolean.class.isAssignableFrom(klass.getRawType()) || boolean.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Boolean.class.isAssignableFrom(type.getRawType()) || boolean.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ByteDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ByteDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.nio.charset.Charset;
@@ -25,8 +26,8 @@ public final class ByteDecoder extends LeafDecoder<Byte> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Byte.class.isAssignableFrom(klass.getRawType()) || byte.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Byte.class.isAssignableFrom(type.getRawType()) || byte.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/CharDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/CharDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.util.ArrayList;
@@ -26,8 +27,8 @@ public final class CharDecoder extends LeafDecoder<Character> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Character.class.isAssignableFrom(klass.getRawType()) || char.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Character.class.isAssignableFrom(type.getRawType()) || char.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DateDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DateDecoder.java
@@ -4,6 +4,7 @@ import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.time.Instant;
@@ -60,8 +61,8 @@ public final class DateDecoder extends LeafDecoder<Date> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Date.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Date.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/Decoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/Decoder.java
@@ -40,10 +40,13 @@ public interface Decoder<T> {
     /**
      * true if this decoder matches the type capture.
      *
-     * @param klass TypeCapture we are looking for a decoder.
+     * @param path           the current path
+     * @param tags           the tags for the current request
+     * @param node           the current node we are decoding.
+     * @param type           the type of object we are decoding.
      * @return true if this decoder matches the type capture
      */
-    boolean matches(TypeCapture<?> klass);
+    boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type);
 
     /**
      * Decode the current node. If the current node is a class or list we may need to decode sub nodes.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DecoderRegistry.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DecoderRegistry.java
@@ -104,10 +104,10 @@ public final class DecoderRegistry implements DecoderService {
      * @return a list of decoders that match the class
      */
     @SuppressWarnings("rawtypes")
-    <T> List<Decoder> getDecoderForClass(TypeCapture<T> klass) {
+    <T> List<Decoder> getDecoderForClass(String path, Tags tags, ConfigNode configNode, TypeCapture<T> klass) {
         return decoders
             .stream()
-            .filter(decoder -> decoder.matches(klass))
+            .filter(decoder -> decoder.canDecode(path, tags, configNode, klass))
             .collect(Collectors.toList());
     }
 
@@ -121,7 +121,7 @@ public final class DecoderRegistry implements DecoderService {
     @SuppressWarnings({"rawtypes", "unchecked"})
     public <T> ValidateOf<T> decodeNode(String path, Tags tags, ConfigNode configNode, TypeCapture<T> klass,
                                         DecoderContext decoderContext) {
-        List<Decoder> classDecoder = getDecoderForClass(klass);
+        List<Decoder> classDecoder = getDecoderForClass(path, tags, configNode, klass);
         classDecoder.sort(Comparator.comparingInt(v -> v.priority().ordinal()));
         if (classDecoder.isEmpty()) {
             return ValidateOf.inValid(new ValidationError.NoDecodersFound(klass.getName()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DoubleDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DoubleDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -24,8 +25,8 @@ public final class DoubleDecoder extends LeafDecoder<Double> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Double.class.isAssignableFrom(klass.getRawType()) || double.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Double.class.isAssignableFrom(type.getRawType()) || double.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -26,8 +27,8 @@ public final class DurationDecoder extends LeafDecoder<Duration> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Duration.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Duration.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/EnumDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/EnumDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.lang.reflect.InvocationTargetException;
@@ -26,8 +27,8 @@ public final class EnumDecoder<T extends Enum<T>> extends LeafDecoder<T> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return klass.getRawType().isEnum();
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return type.getRawType().isEnum();
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FileDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FileDecoder.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.io.File;
@@ -26,8 +27,8 @@ public final class FileDecoder extends LeafDecoder<File> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return File.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return File.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FloatDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FloatDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -24,8 +25,8 @@ public final class FloatDecoder extends LeafDecoder<Float> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Float.class.isAssignableFrom(klass.getRawType()) || float.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Float.class.isAssignableFrom(type.getRawType()) || float.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/InstantDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/InstantDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.time.Instant;
@@ -26,8 +27,8 @@ public final class InstantDecoder extends LeafDecoder<Instant> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Instant.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Instant.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/IntegerDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/IntegerDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -24,8 +25,8 @@ public final class IntegerDecoder extends LeafDecoder<Integer> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Integer.class.isAssignableFrom(klass.getRawType()) || int.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Integer.class.isAssignableFrom(type.getRawType()) || int.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ListDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ListDecoder.java
@@ -23,8 +23,8 @@ public final class ListDecoder extends CollectionDecoder<List<?>> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return List.class.isAssignableFrom(klass.getRawType()) && klass.hasParameter();
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return List.class.isAssignableFrom(type.getRawType()) && type.hasParameter();
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateDecoder.java
@@ -4,6 +4,7 @@ import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.time.LocalDate;
@@ -57,8 +58,8 @@ public final class LocalDateDecoder extends LeafDecoder<LocalDate> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return LocalDate.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return LocalDate.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateTimeDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateTimeDecoder.java
@@ -4,6 +4,7 @@ import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.time.LocalDateTime;
@@ -57,8 +58,8 @@ public final class LocalDateTimeDecoder extends LeafDecoder<LocalDateTime> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return LocalDateTime.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return LocalDateTime.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LongDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LongDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -24,8 +25,8 @@ public final class LongDecoder extends LeafDecoder<Long> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Long.class.isAssignableFrom(klass.getRawType()) || long.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Long.class.isAssignableFrom(type.getRawType()) || long.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
@@ -34,7 +34,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return Map.class.isAssignableFrom(type.getRawType()) && type.hasParameter();
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ObjectDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ObjectDecoder.java
@@ -50,9 +50,9 @@ public final class ObjectDecoder implements Decoder<Object> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return !klass.getRawType().isPrimitive() && !klass.isArray() && !klass.isEnum() &&
-            !klass.hasParameter() && !klass.isInterface() && !ignoreTypes.contains(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return !type.getRawType().isPrimitive() && !type.isArray() && !type.isEnum() &&
+            !type.hasParameter() && !type.isInterface() && !ignoreTypes.contains(type.getRawType());
     }
 
     private Set<Class<?>> getIgnoreTypes() {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDecoder.java
@@ -25,7 +25,7 @@ public final class OptionalDecoder implements Decoder<Optional<?>> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return Optional.class.isAssignableFrom(type.getRawType());
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDoubleDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDoubleDecoder.java
@@ -25,7 +25,7 @@ public final class OptionalDoubleDecoder implements Decoder<OptionalDouble> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return OptionalDouble.class.isAssignableFrom(type.getRawType());
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalIntDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalIntDecoder.java
@@ -25,7 +25,7 @@ public final class OptionalIntDecoder implements Decoder<OptionalInt> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return OptionalInt.class.isAssignableFrom(type.getRawType());
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalLongDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalLongDecoder.java
@@ -25,7 +25,7 @@ public final class OptionalLongDecoder implements Decoder<OptionalLong> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return OptionalLong.class.isAssignableFrom(type.getRawType());
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/PathDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/PathDecoder.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.nio.file.Path;
@@ -25,8 +26,8 @@ public final class PathDecoder extends LeafDecoder<Path> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Path.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Path.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/PatternDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/PatternDecoder.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.util.regex.Pattern;
@@ -24,8 +25,8 @@ public final class PatternDecoder extends LeafDecoder<Pattern> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Pattern.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Pattern.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ProxyDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ProxyDecoder.java
@@ -68,10 +68,10 @@ public final class ProxyDecoder implements Decoder<Object> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return klass.isInterface() &&
-            !Collection.class.isAssignableFrom(klass.getRawType()) &&
-            !Map.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return type.isInterface() &&
+            !Collection.class.isAssignableFrom(type.getRawType()) &&
+            !Map.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/RecordDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/RecordDecoder.java
@@ -35,8 +35,8 @@ public final class RecordDecoder implements Decoder<Object> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return RecordUtils.isRecord(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return RecordUtils.isRecord(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/SetDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/SetDecoder.java
@@ -25,7 +25,7 @@ public final class SetDecoder extends CollectionDecoder<Set<?>> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> type) {
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
         return Set.class.isAssignableFrom(type.getRawType()) && type.hasParameter();
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ShortDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ShortDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.StringUtils;
 import org.github.gestalt.config.utils.ValidateOf;
 
@@ -24,8 +25,8 @@ public final class ShortDecoder extends LeafDecoder<Short> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return Short.class.isAssignableFrom(klass.getRawType()) || short.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return Short.class.isAssignableFrom(type.getRawType()) || short.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/StringDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/StringDecoder.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 /**
@@ -22,8 +23,8 @@ public final class StringDecoder extends LeafDecoder<String> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return String.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return String.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/UUIDDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/UUIDDecoder.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.reflect.TypeCapture;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ValidateOf;
 
 import java.util.UUID;
@@ -25,8 +26,8 @@ public final class UUIDDecoder extends LeafDecoder<UUID> {
     }
 
     @Override
-    public boolean matches(TypeCapture<?> klass) {
-        return UUID.class.isAssignableFrom(klass.getRawType());
+    public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
+        return UUID.class.isAssignableFrom(type.getRawType());
     }
 
     @Override

--- a/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
@@ -1868,7 +1868,7 @@ class GestaltTest {
         }
 
         @Override
-        public boolean matches(TypeCapture<?> klass) {
+        public boolean canDecode(String path, Tags tags, ConfigNode configNode, TypeCapture<?> klass) {
             return String.class.isAssignableFrom(klass.getRawType());
         }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ArrayDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ArrayDecoderTest.java
@@ -50,35 +50,35 @@ class ArrayDecoderTest {
 
     @Test
     @SuppressWarnings({"rawtypes", "unchecked"})
-    void matches() {
+    void canDecode() {
         ArrayDecoder decoder = new ArrayDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(int[].class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<int[]>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(int[].class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<int[]>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Integer[].class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Integer[]>() {
-        }));
-
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(DBInfo[].class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<DBInfo[]>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer[].class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Integer[]>() {
         }));
 
-
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<String>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo[].class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<DBInfo[]>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<String>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(List.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Set.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Set<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(List.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<String>>() {
+        }));
+
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Set.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Set<String>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigDecimalDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigDecimalDecoderTest.java
@@ -50,24 +50,24 @@ class BigDecimalDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         BigDecimalDecoder decoder = new BigDecimalDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(BigDecimal.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<BigDecimal>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(BigDecimal.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<BigDecimal>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(double.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(double.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Double.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Double>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Double>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(double.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(double.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Integer>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Integer>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Double>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Double>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigIntegerDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigIntegerDecoderTest.java
@@ -46,23 +46,23 @@ class BigIntegerDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         BigIntegerDecoder decoder = new BigIntegerDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(BigInteger.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<BigInteger>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(BigInteger.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<BigInteger>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Double.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Double>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Double>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(double.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(double.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Integer>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Integer>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Double>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Double>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BooleanDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BooleanDecoderTest.java
@@ -45,18 +45,18 @@ class BooleanDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         BooleanDecoder decoder = new BooleanDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Boolean.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Boolean>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Boolean.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Boolean>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(boolean.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(boolean.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ByteDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ByteDecoderTest.java
@@ -46,19 +46,19 @@ class ByteDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         ByteDecoder decoder = new ByteDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Byte.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Byte>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Byte.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Byte>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(byte.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(byte.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Character.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Float.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Float>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Character.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Float.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Float>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/CharDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/CharDecoderTest.java
@@ -44,18 +44,18 @@ class CharDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         CharDecoder decoder = new CharDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Character.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Character>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Character.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Character>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(char.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(char.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Float.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Float>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Float.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Float>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DateDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DateDecoderTest.java
@@ -53,12 +53,12 @@ class DateDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         DateDecoder decoder = new DateDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Pattern.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Pattern.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderRegistryTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderRegistryTest.java
@@ -75,10 +75,10 @@ class DecoderRegistryTest {
         DecoderRegistry decoderRegistry = new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(),
             new StringDecoder()), configNodeService, lexer, List.of(new StandardPathMapper()));
 
-        List<Decoder> decoders = decoderRegistry.getDecoderForClass(TypeCapture.of(String.class));
+        List<Decoder> decoders = decoderRegistry.getDecoderForClass("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class));
 
         Assertions.assertEquals(1, decoders.size());
-        Assertions.assertTrue(decoders.get(0).matches(TypeCapture.of(String.class)));
+        Assertions.assertTrue(decoders.get(0).canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
     }
 
     @Test
@@ -86,16 +86,16 @@ class DecoderRegistryTest {
         DecoderRegistry decoderRegistry = new DecoderRegistry(Collections.singletonList(new StringDecoder()), configNodeService, lexer,
             List.of(new StandardPathMapper()));
 
-        List<Decoder> decoders = decoderRegistry.getDecoderForClass(TypeCapture.of(Double.class));
+        List<Decoder> decoders = decoderRegistry.getDecoderForClass("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class));
 
         Assertions.assertEquals(0, decoders.size());
 
         decoderRegistry.addDecoders(Collections.singletonList(new DoubleDecoder()));
 
-        decoders = decoderRegistry.getDecoderForClass(TypeCapture.of(Double.class));
+        decoders = decoderRegistry.getDecoderForClass("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class));
 
         Assertions.assertEquals(1, decoders.size());
-        Assertions.assertTrue(decoders.get(0).matches(TypeCapture.of(Double.class)));
+        Assertions.assertTrue(decoders.get(0).canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class)));
     }
 
     @Test
@@ -420,7 +420,7 @@ class DecoderRegistryTest {
         }
 
         @Override
-        public boolean matches(TypeCapture<?> klass) {
+        public boolean canDecode(String path, Tags tags, ConfigNode configNode, TypeCapture<?> klass) {
             return Long.class.isAssignableFrom(klass.getRawType()) || long.class.isAssignableFrom(klass.getRawType());
         }
 
@@ -444,7 +444,7 @@ class DecoderRegistryTest {
         }
 
         @Override
-        public boolean matches(TypeCapture<?> klass) {
+        public boolean canDecode(String path, Tags tags, ConfigNode configNode, TypeCapture<?> klass) {
             return Long.class.isAssignableFrom(klass.getRawType()) || long.class.isAssignableFrom(klass.getRawType());
         }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DoubleDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DoubleDecoderTest.java
@@ -45,19 +45,19 @@ class DoubleDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         DoubleDecoder doubleDecoder = new DoubleDecoder();
 
-        Assertions.assertTrue(doubleDecoder.matches(TypeCapture.of(Double.class)));
-        Assertions.assertTrue(doubleDecoder.matches(new TypeCapture<Double>() {
+        Assertions.assertTrue(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Double.class)));
+        Assertions.assertTrue(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Double>() {
         }));
-        Assertions.assertTrue(doubleDecoder.matches(TypeCapture.of(double.class)));
+        Assertions.assertTrue(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(double.class)));
 
-        Assertions.assertFalse(doubleDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(doubleDecoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(doubleDecoder.matches(new TypeCapture<Integer>() {
+        Assertions.assertFalse(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Integer>() {
         }));
-        Assertions.assertFalse(doubleDecoder.matches(new TypeCapture<List<Double>>() {
+        Assertions.assertFalse(doubleDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Double>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
@@ -47,17 +47,17 @@ class DurationDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         DurationDecoder decoder = new DurationDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Duration.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Duration>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Duration.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Duration>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/EnumDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/EnumDecoderTest.java
@@ -47,15 +47,15 @@ class EnumDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         EnumDecoder decoder = new EnumDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Colours.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Colours>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Colours.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Colours>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfo.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FileDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FileDecoderTest.java
@@ -50,12 +50,12 @@ class FileDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         FileDecoder decoder = new FileDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(File.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(File.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FloatDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FloatDecoderTest.java
@@ -45,17 +45,17 @@ class FloatDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         FloatDecoder floatDecoder = new FloatDecoder();
 
-        Assertions.assertTrue(floatDecoder.matches(TypeCapture.of(Float.class)));
-        Assertions.assertTrue(floatDecoder.matches(new TypeCapture<Float>() {
+        Assertions.assertTrue(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Float.class)));
+        Assertions.assertTrue(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Float>() {
         }));
-        Assertions.assertTrue(floatDecoder.matches(TypeCapture.of(float.class)));
+        Assertions.assertTrue(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(float.class)));
 
-        Assertions.assertFalse(floatDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(floatDecoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(floatDecoder.matches(new TypeCapture<List<Float>>() {
+        Assertions.assertFalse(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(floatDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Float>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/InstantDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/InstantDecoderTest.java
@@ -48,12 +48,12 @@ class InstantDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         InstantDecoder decoder = new InstantDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Instant.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Instant.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/IntegerDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/IntegerDecoderTest.java
@@ -45,17 +45,17 @@ class IntegerDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         IntegerDecoder integerDecoder = new IntegerDecoder();
 
-        Assertions.assertTrue(integerDecoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertTrue(integerDecoder.matches(new TypeCapture<Integer>() {
+        Assertions.assertTrue(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertTrue(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Integer>() {
         }));
-        Assertions.assertTrue(integerDecoder.matches(TypeCapture.of(int.class)));
+        Assertions.assertTrue(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(int.class)));
 
-        Assertions.assertFalse(integerDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(integerDecoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(integerDecoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(integerDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ListDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ListDecoderTest.java
@@ -47,22 +47,22 @@ class ListDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         ListDecoder decoder = new ListDecoder();
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<String>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<String>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(List.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<List<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(List.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<String>>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Set.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Set<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Set.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Set<String>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateDecoderTest.java
@@ -50,13 +50,13 @@ class LocalDateDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         LocalDateDecoder decoder = new LocalDateDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(LocalDate.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(LocalDateTime.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(LocalDate.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(LocalDateTime.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateTimeDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateTimeDecoderTest.java
@@ -50,12 +50,12 @@ class LocalDateTimeDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         LocalDateTimeDecoder decoder = new LocalDateTimeDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(LocalDateTime.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(LocalDateTime.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LongDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LongDecoderTest.java
@@ -45,17 +45,17 @@ class LongDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         LongDecoder longDecoder = new LongDecoder();
 
-        Assertions.assertTrue(longDecoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertTrue(longDecoder.matches(new TypeCapture<Long>() {
+        Assertions.assertTrue(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertTrue(longDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
-        Assertions.assertTrue(longDecoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertTrue(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(longDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(longDecoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(longDecoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
@@ -42,21 +42,21 @@ class MapDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         MapDecoder decoder = new MapDecoder();
 
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Map<String, Long>>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Map<String, Long>>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfo.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ObjectDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ObjectDecoderTest.java
@@ -52,23 +52,23 @@ class ObjectDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         ObjectDecoder decoder = new ObjectDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(DBInfo.class)));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(DBInfoExtended.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfoExtended.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Map<String, Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Map<String, Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<DBInfoGeneric<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<DBInfoGeneric<String>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDecoderTest.java
@@ -52,17 +52,17 @@ class OptionalDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         OptionalDecoder decoder = new OptionalDecoder();
 
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Optional<Short>>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Optional<Short>>() {
         }));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Optional<List<Short>>>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Optional<List<Short>>>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
 
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDoubleDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDoubleDecoderTest.java
@@ -51,16 +51,16 @@ class OptionalDoubleDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         OptionalDoubleDecoder decoder = new OptionalDoubleDecoder();
 
-        Assertions.assertTrue(decoder.matches(new TypeCapture<OptionalDouble>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<OptionalDouble>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(OptionalDouble.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(OptionalDouble.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
 
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalIntDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalIntDecoderTest.java
@@ -51,16 +51,16 @@ class OptionalIntDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         OptionalIntDecoder decoder = new OptionalIntDecoder();
 
-        Assertions.assertTrue(decoder.matches(new TypeCapture<OptionalInt>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<OptionalInt>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(OptionalInt.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(OptionalInt.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
 
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalLongDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalLongDecoderTest.java
@@ -51,16 +51,16 @@ class OptionalLongDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         OptionalLongDecoder decoder = new OptionalLongDecoder();
 
-        Assertions.assertTrue(decoder.matches(new TypeCapture<OptionalLong>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<OptionalLong>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(OptionalLong.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(OptionalLong.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
 
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PathDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PathDecoderTest.java
@@ -51,12 +51,12 @@ class PathDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         PathDecoder decoder = new PathDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Path.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Path.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PatternDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PatternDecoderTest.java
@@ -48,12 +48,12 @@ class PatternDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         PatternDecoder decoder = new PatternDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Pattern.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Pattern.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
@@ -45,31 +45,31 @@ class ProxyDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         ProxyDecoder decoder = new ProxyDecoder();
 
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Set<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Set<Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Map<Long, String>>() {
-        }));
-
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(DBInfoInterface.class)));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(DBPoolInterface.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<DBPoolInterface>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Map<Long, String>>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfo.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfoExtended.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfoInterface.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBPoolInterface.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<DBPoolInterface>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfoExtended.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
+        }));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
+
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/SetDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/SetDecoderTest.java
@@ -49,22 +49,22 @@ class SetDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         SetDecoder decoder = new SetDecoder();
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<String>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<String>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(List.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(List.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<String>>() {
         }));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Set.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Set<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Set.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Set<String>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ShortDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ShortDecoderTest.java
@@ -45,17 +45,17 @@ class ShortDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         ShortDecoder decoder = new ShortDecoder();
 
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(Short.class)));
-        Assertions.assertTrue(decoder.matches(new TypeCapture<Short>() {
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Short.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Short>() {
         }));
-        Assertions.assertTrue(decoder.matches(TypeCapture.of(short.class)));
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(short.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Integer>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Integer>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/StringAndLeafDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/StringAndLeafDecoderTest.java
@@ -47,12 +47,12 @@ class StringAndLeafDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         StringDecoder stringDecoder = new StringDecoder();
 
-        Assertions.assertTrue(stringDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(stringDecoder.matches(TypeCapture.of(Integer.class)));
-        Assertions.assertFalse(stringDecoder.matches(TypeCapture.of(Date.class)));
+        Assertions.assertTrue(stringDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(stringDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Integer.class)));
+        Assertions.assertFalse(stringDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/UUIDDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/UUIDDecoderTest.java
@@ -46,17 +46,17 @@ class UUIDDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         UUIDDecoder longDecoder = new UUIDDecoder();
 
-        Assertions.assertTrue(longDecoder.matches(TypeCapture.of(UUID.class)));
-        Assertions.assertTrue(longDecoder.matches(new TypeCapture<UUID>() {
+        Assertions.assertTrue(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(UUID.class)));
+        Assertions.assertTrue(longDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<UUID>() {
         }));
-        Assertions.assertFalse(longDecoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(longDecoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(longDecoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(longDecoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(longDecoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/ConfigLoaderRegistryTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/ConfigLoaderRegistryTest.java
@@ -76,7 +76,7 @@ class ConfigLoaderRegistryTest {
     }
 
     @Test
-    void testMultipleLoaderMatches() throws GestaltConfigurationException {
+    void testMultipleLoadercanDecode() throws GestaltConfigurationException {
         ConfigLoader loader = Mockito.mock(ConfigLoader.class);
         Mockito.when(loader.accepts("test")).thenReturn(true);
         Mockito.when(loader.accepts("noMatch")).thenReturn(false);

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoder.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.Priority
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.ValidateOf
 
 /**
@@ -21,7 +22,7 @@ class BooleanDecoder : LeafDecoder<Boolean>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Boolean::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.ValidateOf
 import java.nio.charset.Charset
 
@@ -23,7 +24,7 @@ class ByteDecoder : LeafDecoder<Byte>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Byte::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.ValidateOf
 
 /**
@@ -22,7 +23,7 @@ class CharDecoder : LeafDecoder<Char>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Char::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
@@ -39,7 +39,7 @@ class DataClassDecoder : Decoder<Any> {
         return Priority.MEDIUM
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         if (klass is KTypeCapture<*>) {
             val classifier = klass.kType.classifier
 

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.StringUtils
 import org.github.gestalt.config.utils.ValidateOf
 
@@ -23,7 +24,7 @@ class DoubleDecoder : LeafDecoder<Double>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Double::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.StringUtils
 import org.github.gestalt.config.utils.ValidateOf
 
@@ -23,7 +24,7 @@ class FloatDecoder : LeafDecoder<Float>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Float::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.StringUtils
 import org.github.gestalt.config.utils.ValidateOf
 
@@ -23,7 +24,7 @@ class IntegerDecoder : LeafDecoder<Int>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Int::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.StringUtils
 import org.github.gestalt.config.utils.ValidateOf
 
@@ -23,7 +24,7 @@ class LongDecoder : LeafDecoder<Long>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Long::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoder.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationError
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.StringUtils
 import org.github.gestalt.config.utils.ValidateOf
 
@@ -23,7 +24,7 @@ class ShortDecoder : LeafDecoder<Short>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(Short::class)
         } else {

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/StringDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/StringDecoder.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.Priority
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.node.ConfigNode
 import org.github.gestalt.config.reflect.TypeCapture
+import org.github.gestalt.config.tag.Tags
 import org.github.gestalt.config.utils.ValidateOf
 
 /**
@@ -21,7 +22,7 @@ class StringDecoder : LeafDecoder<String>() {
         return Priority.HIGH
     }
 
-    override fun matches(klass: TypeCapture<*>): Boolean {
+    override fun canDecode(path: String, tags: Tags, configNode:ConfigNode?, klass: TypeCapture<*>): Boolean {
         return if (klass is KTypeCapture<*>) {
             klass.isAssignableFrom(String::class)
         } else {

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoderTest.kt
@@ -46,16 +46,16 @@ internal class BooleanDecoderTest {
 
     @ExperimentalStdlibApi
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = BooleanDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Boolean>()))
-        Assertions.assertTrue(decoder.matches(KTypeCapture.of<Boolean>(typeOf<Boolean>())))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Boolean?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Boolean::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Boolean>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), KTypeCapture.of<Boolean>(typeOf<Boolean>())))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Boolean?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Boolean::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoderTest.kt
@@ -44,15 +44,15 @@ internal class ByteDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = ByteDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Byte>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Byte?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Byte::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Byte>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Byte?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Byte::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoderTest.kt
@@ -43,15 +43,15 @@ internal class CharDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = CharDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Char>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Char?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Char::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Char>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Char?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Char::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoderTest.kt
@@ -47,18 +47,18 @@ class DataClassDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = DataClassDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<DBInfo>()))
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<DBInfoNoDefault>()))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfoNoDefault::class.java)))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long::class.java)))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Long?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long::class.javaPrimitiveType)))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<List<Long?>?>() {}))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Map<String?, Long?>?>() {}))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<DBInfo>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<DBInfoNoDefault>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(DBInfoNoDefault::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Long::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Long?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Long::class.javaPrimitiveType)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(String::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<List<Long?>?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Map<String?, Long?>?>() {}))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoderTest.kt
@@ -43,15 +43,15 @@ internal class DoubleDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = DoubleDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Double>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Double?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Double::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Double>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Double?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Double::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoderTest.kt
@@ -43,15 +43,15 @@ internal class FloatDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = FloatDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Float>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Float?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Float::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Float>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Float?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Float::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoderTest.kt
@@ -43,14 +43,14 @@ internal class IntegerDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = IntegerDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Int?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Int::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Int?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Int::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoderTest.kt
@@ -43,15 +43,15 @@ internal class LongDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = LongDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Long>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Long?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Long>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Long?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Long::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoderTest.kt
@@ -43,15 +43,15 @@ internal class ShortDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = ShortDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<Short>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<Short?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Short::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Short>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<Short?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(Short::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/StringAndLeafDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/StringAndLeafDecoderTest.kt
@@ -44,14 +44,14 @@ internal class StringAndLeafDecoderTest {
     }
 
     @Test
-    fun matches() {
+    fun canDecode() {
         val decoder = StringDecoder()
-        Assertions.assertTrue(decoder.matches(kTypeCaptureOf<String>()))
-        Assertions.assertFalse(decoder.matches(object : TypeCapture<String?>() {}))
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String::class.java)))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Int>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<Date>()))
-        Assertions.assertFalse(decoder.matches(kTypeCaptureOf<List<Byte>>()))
+        Assertions.assertTrue(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<String>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), object : TypeCapture<String?>() {}))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), TypeCapture.of(String::class.java)))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Int>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<Date>()))
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), LeafNode(""), kTypeCaptureOf<List<Byte>>()))
     }
 
     @Test

--- a/gestalt-test/src/test/java/org/github/gestalt/config/decoder/RecordDecoderTest.java
+++ b/gestalt-test/src/test/java/org/github/gestalt/config/decoder/RecordDecoderTest.java
@@ -46,23 +46,23 @@ class RecordDecoderTest {
     }
 
     @Test
-    void matches() {
+    void canDecode() {
         RecordDecoder decoder = new RecordDecoder();
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfo.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(DBInfoExtended.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Long.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Long>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfo.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(DBInfoExtended.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Long>() {
         }));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(long.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(long.class)));
 
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(String.class)));
-        Assertions.assertFalse(decoder.matches(TypeCapture.of(Date.class)));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<List<Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(String.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<Map<String, Long>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<Map<String, Long>>() {
         }));
-        Assertions.assertFalse(decoder.matches(new TypeCapture<DBInfoGeneric<String>>() {
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<DBInfoGeneric<String>>() {
         }));
     }
 


### PR DESCRIPTION
feat: change signature of decoder match to canDecode(path: String, tags: Tags, configNode:ConfigNode, TypeCapture<?> klass) so we have more information to decide how to decode the class. 