### PR TITLE
fix: make the TimedConfigReloadStrategy Timer a daemon thread. https://github.com/gestalt-config/gestalt/issues/126

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 allprojects {
     group = "com.github.gestalt-config"
-    version = "0.24.0"
+    version = "0.24.1"
 }
 
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/TimedConfigReloadStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/TimedConfigReloadStrategy.java
@@ -16,7 +16,7 @@ import java.util.TimerTask;
 public final class TimedConfigReloadStrategy extends ConfigReloadStrategy {
     private static final System.Logger logger = System.getLogger(TimedConfigReloadStrategy.class.getName());
 
-    private final Timer timer = new Timer();
+    private final Timer timer = new Timer(true);
     private final Duration reloadDelay;
 
     /**


### PR DESCRIPTION
fix: make the TimedConfigReloadStrategy Timer a daemon thread. https://github.com/gestalt-config/gestalt/issues/126