### PR TITLE
Feat: Extend DurationDecoder to parse Duration

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
@@ -44,7 +44,11 @@ public final class DurationDecoder extends LeafDecoder<Duration> {
                 results = GResultOf.errors(new ValidationError.ErrorDecodingException(path, node, name()));
             }
         } else {
-            results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));
+            try {
+                results = GResultOf.result(Duration.parse(value));
+            } catch (Exception e) {
+                results = GResultOf.errors(new ValidationError.ErrorDecodingException(path, node, name()));
+            }
         }
         return results;
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
@@ -73,6 +73,18 @@ class DurationDecoderTest {
     }
 
     @Test
+    void decodeISO8601() {
+        DurationDecoder decoder = new DurationDecoder();
+
+        GResultOf<Duration> result = decoder.decode("db.port", Tags.of(), new LeafNode("PT20S"),
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null));
+        Assertions.assertTrue(result.hasResults());
+        Assertions.assertFalse(result.hasErrors());
+        Assertions.assertEquals(Duration.ofSeconds(20), result.results());
+        Assertions.assertEquals(0, result.getErrors().size());
+    }
+
+    @Test
     void decodeInvalidNode() {
         DurationDecoder decoder = new DurationDecoder();
 
@@ -83,8 +95,7 @@ class DurationDecoderTest {
         Assertions.assertNull(result.results());
         Assertions.assertNotNull(result.getErrors());
         Assertions.assertEquals(ValidationLevel.ERROR, result.getErrors().get(0).level());
-        Assertions.assertEquals("Unable to parse a number on Path: db.port, from node: LeafNode{value='12s4'} " +
-                "attempting to decode Duration",
+        Assertions.assertEquals("Unable to decode a Duration on path: db.port, from node: LeafNode{value='12s4'}",
             result.getErrors().get(0).description());
     }
 


### PR DESCRIPTION
 Extend Duration Decoder to parse Duration so that it is able to decode Durations written in ISO 8601 standardized string format like "PT42S"?  Address issue https://github.com/gestalt-config/gestalt/issues/137