### PR TITLE
feat: Support ignoring case when matching the prefix for Env Vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,6 +1038,15 @@ In the end we should get the value 200 based on the overridden Environment Varia
 
 If you wish to use a different case then Screaming Snake Case, you would need to provide your own EnvironmentVarsLoader with your specific SentenceLexer lexer. 
 
+There are several configuration options on the `EnvironmentConfigSource`, 
+
+| Configuration Name | Default | Description                                                                                                                                   |
+|--------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| failOnErrors       | false   | If we should fail on errors. By default the Environment Config Source pulls in all Environment variables, and several may not parse correctly |
+| prefix             | ""      | By provide a prefix only Env Vars that start with the prefix will be included.                                                                |
+| ignoreCaseOnPrefix | false   | Define if we want to ignore the case when matching the prefix.                                                                                |
+| removePrefix       | false   | If we should remove the prefix and the following "_" or"." from the imported configuration                                                    |
+
 
 # Example code
 For more examples of how to use gestalt see the [gestalt-sample](https://github.com/gestalt-config/gestalt/tree/main/gestalt-examples/gestalt-sample/src/test) or for Java 17 + samples [gestalt-sample-java-latest](https://github.com/gestalt-config/gestalt/tree/main/gestalt-examples/gestalt-sample-java-latest/src/test)
@@ -1212,3 +1221,4 @@ public interface Transformer {
 To register your own default Transformer, add it to a file in META-INF\services\org.github.gestalt.config.post.process.transform.Transformer and add the full path to your Transformer.
 
 the annotation @ConfigPriority(100), specifies the descending priority order to check your transformer when a substitution has been made without specifying the source ${key}
+

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
@@ -18,6 +18,8 @@ public final class EnvironmentConfigSourceBuilder extends SourceBuilder<Environm
 
     private String prefix = "";
 
+    private boolean ignoreCaseOnPrefix = false;
+
     private boolean removePrefix = false;
 
     /**
@@ -65,6 +67,7 @@ public final class EnvironmentConfigSourceBuilder extends SourceBuilder<Environm
         return prefix;
     }
 
+
     /**
      * Set the prefix we scan for. This will only include the environment variables that match the prefix.
      *
@@ -73,6 +76,26 @@ public final class EnvironmentConfigSourceBuilder extends SourceBuilder<Environm
      */
     public EnvironmentConfigSourceBuilder setPrefix(String prefix) {
         this.prefix = prefix;
+        return this;
+    }
+
+    /**
+     * Gets if we should ignore the case when matching the prefix.
+     *
+     * @return if we should ignore the case when matching the prefix.
+     */
+    public boolean isIgnoreCaseOnPrefix() {
+        return ignoreCaseOnPrefix;
+    }
+
+    /**
+     * Sets if we should ignore the case when matching the prefix.
+     *
+     * @param ignoreCaseOnPrefix if we should ignore the case when matching the prefix.
+     * @return the builder
+     */
+    public EnvironmentConfigSourceBuilder setIgnoreCaseOnPrefix(boolean ignoreCaseOnPrefix) {
+        this.ignoreCaseOnPrefix = ignoreCaseOnPrefix;
         return this;
     }
 
@@ -98,6 +121,6 @@ public final class EnvironmentConfigSourceBuilder extends SourceBuilder<Environm
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new EnvironmentConfigSource(prefix, removePrefix, failOnErrors, tags));
+        return buildPackage(new EnvironmentConfigSource(prefix, ignoreCaseOnPrefix, removePrefix, failOnErrors, tags));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/StringUtils.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/StringUtils.java
@@ -6,9 +6,8 @@ package org.github.gestalt.config.utils;
  * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
  */
 public final class StringUtils {
-    private StringUtils() {
 
-    }
+    private StringUtils() { }
 
     /**
      * Returns true if a string is an integer.
@@ -107,5 +106,15 @@ public final class StringUtils {
             }
         }
         return true;
+    }
+
+    public static boolean startsWith(String str, String prefix, boolean ignoreCase) {
+        if (str == null || prefix == null) {
+            return str == null && prefix == null;
+        }
+        if (prefix.length() > str.length()) {
+            return false;
+        }
+        return str.regionMatches(ignoreCase, 0, prefix, 0, prefix.length());
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilderTest.java
@@ -11,18 +11,21 @@ class EnvironmentConfigSourceBuilderTest {
     void testBuild() throws GestaltException {
         // Given
         String prefix = "TEST";
+        boolean ignorePrefixCase = false;
         boolean removePrefix = true;
         boolean failOnErrors = false;
 
         // When
         EnvironmentConfigSourceBuilder builder = EnvironmentConfigSourceBuilder.builder()
             .setPrefix(prefix)
+            .setIgnoreCaseOnPrefix(ignorePrefixCase)
             .setRemovePrefix(removePrefix)
             .setFailOnErrors(failOnErrors);
 
         // Then
         assertAll(
             () -> assertEquals(prefix, builder.getPrefix()),
+            () -> assertEquals(ignorePrefixCase, builder.isIgnoreCaseOnPrefix()),
             () -> assertEquals(removePrefix, builder.isRemovePrefix()),
             () -> assertEquals(failOnErrors, builder.isFailOnErrors())
         );
@@ -34,3 +37,4 @@ class EnvironmentConfigSourceBuilderTest {
         assertNotNull(result.getConfigSource());
     }
 }
+

--- a/gestalt-core/src/test/java/org/github/gestalt/config/utils/StringUtilsTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/utils/StringUtilsTest.java
@@ -55,5 +55,29 @@ class StringUtilsTest {
         Assertions.assertFalse(StringUtils.isReal("3.54s4"));
         Assertions.assertFalse(StringUtils.isReal("3.."));
     }
+
+    @Test
+    void startsWith() {
+        var stringToMatch = "ABC_DEF";
+        Assertions.assertFalse(StringUtils.startsWith(stringToMatch, "DEF", false));
+        Assertions.assertFalse(StringUtils.startsWith(stringToMatch, "DEF", true));
+
+        Assertions.assertTrue(StringUtils.startsWith(stringToMatch, "ABC", false));
+        Assertions.assertTrue(StringUtils.startsWith(stringToMatch, "ABC", true));
+
+        Assertions.assertFalse(StringUtils.startsWith(stringToMatch, "abc", false));
+        Assertions.assertTrue(StringUtils.startsWith(stringToMatch, "abc", true));
+
+        Assertions.assertFalse(StringUtils.startsWith(stringToMatch, "this is a really long prefix", false));
+    }
+
+    @Test
+    void startsWithNull() {
+        Assertions.assertTrue(StringUtils.startsWith(null, null, false));
+        Assertions.assertTrue(StringUtils.startsWith(null, null, true));
+
+        Assertions.assertFalse(StringUtils.startsWith("ABC_DEF", null, false));
+        Assertions.assertFalse(StringUtils.startsWith(null, "ABC", true));
+    }
 }
 


### PR DESCRIPTION
Support ignoring case when matching the prefix for Env Vars. https://github.com/gestalt-config/gestalt/issues/148