### PR TITLE
fix: Weak hashmap implementation was broken, use a WeakReference List

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,13 +795,18 @@ To register your own default Decoders add them to the builder, or add it to a fi
 
 
 # Reload Strategies
-When adding a ConfigSource to the builder, if can you also add a reload strategy for the ConfigSource, when the source changes, or we receive an event to reload the config source Gestalt will get a notification and automatically attempt to reload the config.
+Gestalt is idempotent, as in on calling `loadConfigs()` a config tree is built and will not be updated, even if the underlying sources have changed.
+By using Reload strategies you can tell Gestalt when the specific config source has changed to dynamically update configuration on the fly. Once the config tree has been rebuilt, Gestalt will trigger its own Gestalt Core Reload Listener. So you can get an update that the reload has happened. 
+
+When adding a ConfigSource to the builder, you can choose to a reload strategy. The reload strategy triggers from either a file change, a timer event or a manual call from your code. Each reload strategy is for a specific source, and will not cause all sources to be reloaded, only that source. 
 Once Gestalt has reloaded the config it will send out its own Gestalt Core Reload event. you can add a listener to the builder to get a notification when a Gestalt Core Reload has completed. The Gestalt Cache uses this to clear the cache when a Config Source has changed.
 
 ```java
-  ConfigSourcePackage devFileSource = FileConfigSourceBuilder.builder().setFile(devFile).addConfigReloadStrategy(new FileChangeReloadStrategy()).build();
   Gestalt gestalt = builder
-  .addSource(devFileSource)
+  .addSource(FileConfigSourceBuilder.builder()
+      .setFile(devFile)
+      .addConfigReloadStrategy(new FileChangeReloadStrategy())
+      .build())
   .addCoreReloadListener(reloadListener)
   .build();
 ```
@@ -810,6 +815,34 @@ Once Gestalt has reloaded the config it will send out its own Gestalt Core Reloa
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
 | FileChangeReload          | Specify a FileConfigSource, and the  FileChangeReload will listen for changes on that file. When the file changes it will tell Gestalt to reload the file. Also works with symlink and will reload if the symlink change. |
 | TimedConfigReloadStrategy | Provide a ConfigSource and a Duration then the Reload Strategy will reload every period defined by the Duration                                                                                                           |
+| ManualConfigReloadStrategy| You can manually call reload to force a source to reload.                                                                                                                                                                 |
+
+## Dynamic Configuration with Reload Strategies
+
+For example if you want to use a Map Config Source, and have updated values reflected in calls to Gestalt, you can register a `ManualConfigReloadStrategy` with a Map Config Source. Then after you can update the values in the map call `reload()` on the `ManualConfigReloadStrategy` to tell Gestalt you want to rebuild its internal Config Tree. Future calls to Gestalt should reflect the updated values. 
+
+```java
+Map<String, String> configs = new HashMap<>();
+configs.put("some.value", "value1");
+
+var manualReload = new ManualConfigReloadStrategy();
+
+GestaltBuilder builder = new GestaltBuilder();
+Gestalt gestalt = builder
+  .addSource(MapConfigSourceBuilder.builder()
+    .setCustomConfig(configs)
+    .addConfigReloadStrategy(manualReload)
+    .build())
+  .build();
+gestalt.loadConfigs();
+
+Assertions.assertEquals("value1", gestalt.getConfig("some.value", String.class));
+
+configs.put("some.value", "value2");
+
+manualReload.reload();
+Assertions.assertEquals("value2", gestalt.getConfig("some.value", String.class));
+```
 
 # Gestalt configuration
 | Configuration                 | default  | Details                                                                                                                                                                                                                                                                                                          |

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
@@ -7,6 +7,7 @@ import org.github.gestalt.config.exceptions.GestaltException;
  * ConfigSourceBuilder for the Class Path Config Source.
  *
  * <p>Convert the Environment Variables to a property file.
+ * By default, it expects the Environment Variables to be in Screaming Snake Case.
  * Apply the supplied transforms as we convert it.
  * Then write that as an input stream for the next stage in the parsing.
  *

--- a/gestalt-core/src/test/java/org/github/gestalt/config/integration/GestaltIntegrationTests.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/integration/GestaltIntegrationTests.java
@@ -261,6 +261,32 @@ public class GestaltIntegrationTests {
     }
 
     @Test
+    public void integrationTestManualReload() throws GestaltException {
+        Map<String, String> configs = new HashMap<>();
+        configs.put("some.value", "value1");
+
+        var manualReload = new ManualConfigReloadStrategy();
+
+        GestaltBuilder builder = new GestaltBuilder();
+        Gestalt gestalt = builder
+            .addSource(MapConfigSourceBuilder.builder()
+                .setCustomConfig(configs)
+                .addConfigReloadStrategy(manualReload)
+                .build())
+            .build();
+
+        gestalt.loadConfigs();
+
+        Assertions.assertEquals("value1", gestalt.getConfig("some.value", String.class));
+
+        configs.put("some.value", "value2");
+
+        manualReload.reload();
+
+        Assertions.assertEquals("value2", gestalt.getConfig("some.value", String.class));
+    }
+
+    @Test
     public void integrationTestEmpty() throws GestaltException {
         Map<String, String> configs = new HashMap<>();
         configs.put("db.hosts[0].password", "1234");

--- a/gestalt-core/src/test/java/org/github/gestalt/config/reload/CoreReloadListenersContainerTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/reload/CoreReloadListenersContainerTest.java
@@ -1,0 +1,80 @@
+package org.github.gestalt.config.reload;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+class CoreReloadListenersContainerTest {
+
+    @Test
+    void registerListener() {
+
+        var reloadContainer = new CoreReloadListenersContainer();
+
+        TestListener listener1 = new TestListener();
+
+        reloadContainer.registerListener(listener1);
+
+        reloadContainer.reload();
+
+        Assertions.assertEquals(1, listener1.atomicInt.get());
+
+        reloadContainer.reload();
+
+        Assertions.assertEquals(2, listener1.atomicInt.get());
+    }
+
+    @Test
+    void removeListener() {
+
+        var reloadContainer = new CoreReloadListenersContainer();
+
+        TestListener listener1 = new TestListener();
+
+        reloadContainer.registerListener(listener1);
+
+        reloadContainer.reload();
+
+        Assertions.assertEquals(1, listener1.atomicInt.get());
+
+        reloadContainer.removeListener(listener1);
+        reloadContainer.reload();
+
+        Assertions.assertEquals(1, listener1.atomicInt.get());
+
+        var listeners = reloadContainer.getListeners();
+        Assertions.assertEquals(0, listeners.size());
+    }
+
+    @Test
+    void gcedListener() {
+
+        var reloadContainer = new CoreReloadListenersContainer();
+
+        TestListener listener1 = new TestListener();
+
+        reloadContainer.registerListener(listener1);
+
+        reloadContainer.reload();
+
+        Assertions.assertEquals(1, listener1.atomicInt.get());
+
+        listener1 = null;
+        System.gc();
+        reloadContainer.reload();
+
+        var listeners = reloadContainer.getListeners();
+        Assertions.assertEquals(0, listeners.size());
+    }
+
+    static class TestListener implements CoreReloadListener {
+
+        AtomicInteger atomicInt = new AtomicInteger(0);
+
+        @Override
+        public void reload() {
+            atomicInt.addAndGet(1);
+        }
+    }
+}


### PR DESCRIPTION
fix: Weak hashmap implementation was broken, use a WeakReference List instead. Related to issue https://github.com/gestalt-config/gestalt/issues/150

Add additional documentation around reload strategies and how to use them.