### PR TITLE
fix: For path lenghts errors make the error message a little more clear, add the possible cause of duplicate paths.

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
@@ -225,17 +225,18 @@ public abstract class ValidationError {
     /**
      * Mismatched path lengths received for path, this could be because a node is both a leaf and an object.
      */
-    public static class MismatchedPathLength extends ValidationError {
+    public static class PathLengthErrors extends ValidationError {
         private final String paths;
 
-        public MismatchedPathLength(String paths) {
+        public PathLengthErrors(String paths) {
             super(ValidationLevel.ERROR);
             this.paths = paths;
         }
 
         @Override
         public String description() {
-            return "Mismatched path lengths received for path: " + paths + ", this could be because a node is both a leaf and an object";
+            return "Parsing path length errors for path: " + paths +
+                ", there could be several causes such as: duplicate paths, or a node is both a leaf and an object";
         }
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/parser/MapConfigParser.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/parser/MapConfigParser.java
@@ -59,8 +59,8 @@ public final class MapConfigParser implements ConfigParser {
             return GResultOf.result(new LeafNode(configValue.getValue()));
         }
 
-        // result any mis-matched path's, this is most like when a path is both a leaf and an object and an array.
-        List<ValidationError> mismatchedPathLengthErrors = getMismatchedPathLengthErrors(tokens, index, currentPath);
+        // result any mis-matched path's, this is most like when a path is both a duplicate, or leaf and an object and an array.
+        List<ValidationError> mismatchedPathLengthErrors = getPathLengthErrors(tokens, index, currentPath);
         if (!mismatchedPathLengthErrors.isEmpty()) {
             return GResultOf.errors(mismatchedPathLengthErrors);
         }
@@ -250,16 +250,16 @@ public final class MapConfigParser implements ConfigParser {
 
     // We can not have paths with a different lengths, as this means we are at
     // both a leaf and object for the same group of tokens.
-    private List<ValidationError> getMismatchedPathLengthErrors(List<Pair<List<Token>, ConfigValue>> tokens,
-                                                                int index, String currentPath) {
-        List<Pair<List<Token>, ConfigValue>> nodesWithMismatchedPathLengths =
+    private List<ValidationError> getPathLengthErrors(List<Pair<List<Token>, ConfigValue>> tokens,
+                                                      int index, String currentPath) {
+        List<Pair<List<Token>, ConfigValue>> nodesWithSamePathLengths =
             tokens.stream()
                 .filter(tokenPair -> tokenPair.getFirst().size() < index + 1)
                 .collect(Collectors.toList());
 
         List<ValidationError> errorList = new ArrayList<>();
-        if (!nodesWithMismatchedPathLengths.isEmpty()) {
-            errorList.add(new ValidationError.MismatchedPathLength(currentPath));
+        if (!nodesWithSamePathLengths.isEmpty()) {
+            errorList.add(new ValidationError.PathLengthErrors(currentPath));
         }
 
         return errorList;

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/CompilerConfigTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/CompilerConfigTest.java
@@ -113,8 +113,8 @@ class CompilerConfigTest {
         Assertions.assertTrue(results.hasErrors());
 
         Assertions.assertEquals(1, results.getErrors().size());
-        Assertions.assertEquals("Mismatched path lengths received for path: db, this could be because a node is both a leaf " +
-            "and an object", results.getErrors().get(0).description());
+        Assertions.assertEquals("Parsing path length errors for path: db, there could be several causes such as: duplicate paths, " +
+            "or a node is both a leaf and an object", results.getErrors().get(0).description());
     }
 
     private static class MapConfigSourceWarn extends TestMapConfigSource {

--- a/gestalt-core/src/test/java/org/github/gestalt/config/parser/MapConfigParserTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/parser/MapConfigParserTest.java
@@ -315,8 +315,31 @@ class MapConfigParserTest {
         List<ValidationError> results = resultsOf.getErrors();
         assertEquals(1, results.size());
         assertEquals(ValidationLevel.ERROR, results.get(0).level());
-        assertEquals("Mismatched path lengths received for path: db.hosts, " +
-            "this could be because a node is both a leaf and an object", results.get(0).description());
+        assertEquals("Parsing path length errors for path: db.hosts, there could be several causes such as: duplicate paths, " +
+            "or a node is both a leaf and an object", results.get(0).description());
+    }
+
+    @Test
+    public void testValidateDuplicatePathLength() {
+        MapConfigParser mapConfigParser = new MapConfigParser();
+
+        List<Pair<List<Token>, ConfigValue>> test = List.of(
+            new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("connections")), new ConfigValue("10")),
+            new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("user")), new ConfigValue("test")),
+            new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("password")), new ConfigValue("password")),
+            new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts")), new ConfigValue("hostDB1")),
+            new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts")), new ConfigValue("hostDB2"))
+        );
+
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        assertFalse(resultsOf.hasResults());
+        assertTrue(resultsOf.hasErrors());
+        assertNull(resultsOf.results());
+        List<ValidationError> results = resultsOf.getErrors();
+        assertEquals(1, results.size());
+        assertEquals(ValidationLevel.ERROR, results.get(0).level());
+        assertEquals("Parsing path length errors for path: db.hosts, there could be several causes such as: duplicate paths, " +
+            "or a node is both a leaf and an object", results.get(0).description());
     }
 
     @Test
@@ -340,8 +363,8 @@ class MapConfigParserTest {
         List<ValidationError> results = resultsOf.getErrors();
         assertEquals(1, results.size());
         assertEquals(ValidationLevel.ERROR, results.get(0).level());
-        assertEquals("Mismatched path lengths received for path: db.hosts, " +
-            "this could be because a node is both a leaf and an object", results.get(0).description());
+        assertEquals("Parsing path length errors for path: db.hosts, there could be several causes such as: duplicate paths, " +
+            "or a node is both a leaf and an object", results.get(0).description());
     }
 
     @Test
@@ -363,8 +386,8 @@ class MapConfigParserTest {
         List<ValidationError> results = resultsOf.getErrors();
         assertEquals(1, results.size());
         assertEquals(ValidationLevel.ERROR, results.get(0).level());
-        assertEquals("Mismatched path lengths received for path: db, this could be because " +
-            "a node is both a leaf and an object", results.get(0).description());
+        assertEquals("Parsing path length errors for path: db, there could be several causes such as: duplicate paths, " +
+            "or a node is both a leaf and an object", results.get(0).description());
     }
 
     @Test


### PR DESCRIPTION
For path lenghts errors make the error message a little more clear, add the possible cause of duplicate paths.

Add test for duplicate paths.
Partially addresses issue: https://github.com/gestalt-config/gestalt/issues/153