### PR TITLE
feat: add tags to the ConfigSourcePackage and ConfigNodeContainer. 

### DIFF
--- a/gestalt-aws/src/main/java/org/github/gestalt/config/aws/s3/S3ConfigSource.java
+++ b/gestalt-aws/src/main/java/org/github/gestalt/config/aws/s3/S3ConfigSource.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.aws.s3;
 
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.Pair;
 import software.amazon.awssdk.core.ResponseBytes;
@@ -50,7 +51,9 @@ public final class S3ConfigSource implements ConfigSource {
      * @param keyName name of the S3 key
      * @param tags tags associated with the source
      * @throws GestaltException any exceptions thrown
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public S3ConfigSource(S3Client s3, String bucketName, String keyName, Tags tags) throws GestaltException {
         if (s3 == null) {
             throw new GestaltException("S3 client can not be null");

--- a/gestalt-aws/src/main/java/org/github/gestalt/config/aws/s3/S3ConfigSourceBuilder.java
+++ b/gestalt-aws/src/main/java/org/github/gestalt/config/aws/s3/S3ConfigSourceBuilder.java
@@ -97,6 +97,6 @@ public final class S3ConfigSourceBuilder extends SourceBuilder<S3ConfigSourceBui
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new S3ConfigSource(s3, bucketName, keyName, tags));
+        return buildPackage(new S3ConfigSource(s3, bucketName, keyName));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
@@ -167,14 +167,9 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
             throw new GestaltException("No sources provided, unable to reload any configs");
         }
 
-        if (sourcePackages.stream().noneMatch(it -> it.equals(reloadSourcePackage))) {
-            throw new GestaltException("Can not reload a source that was not registered.");
-        }
-
         var sourcePackageOpt = sourcePackages.stream().filter(it -> it.equals(reloadSourcePackage)).findFirst();
-
         if (sourcePackageOpt.isEmpty()) {
-            throw new GestaltException("Config Source not found in registered sources.");
+            throw new GestaltException("Can not reload a source that was not registered.");
         }
 
         var reloadSource = sourcePackageOpt.get().getConfigSource();

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
@@ -201,7 +201,7 @@ public class GestaltBuilder {
     @Deprecated(since = "0.23.4")
     public GestaltBuilder addSource(ConfigSource source) {
         Objects.requireNonNull(source, "Source should not be null");
-        this.configSourcePackages.add(new ConfigSourcePackage(source, List.of()));
+        this.configSourcePackages.add(new ConfigSourcePackage(source, List.of(), source.getTags()));
         return this;
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/SourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/SourceBuilder.java
@@ -7,9 +7,7 @@ import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.tag.Tag;
 import org.github.gestalt.config.tag.Tags;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Base class for all source builders.
@@ -105,12 +103,20 @@ public abstract class SourceBuilder<SELF extends SourceBuilder<SELF, T>, T exten
 
     protected ConfigSourcePackage buildPackage(ConfigSource source) throws GestaltException {
 
-        List<ConfigReloadStrategy> reloadStrategies = new ArrayList<>(configReloadStrategies.size());
-        for (var reloadStrategy : configReloadStrategies) {
-            reloadStrategy.setSource(source);
-            reloadStrategies.add(reloadStrategy);
+        // for now to maintain backwards compatibility add all config source tags to the builder tags
+        Set<Tag> combinedTags = new HashSet<>();
+        if(source.getTags() != null) {
+            combinedTags.addAll(source.getTags().getTags());
         }
-        return new ConfigSourcePackage(source, reloadStrategies);
+        combinedTags.addAll(tags.getTags());
+
+        var configSourcePackage = new ConfigSourcePackage(source, configReloadStrategies, Tags.of(combinedTags));
+
+        for (var reloadStrategy : configReloadStrategies) {
+            reloadStrategy.setSource(configSourcePackage);
+        }
+
+        return configSourcePackage;
     }
 
     @SuppressWarnings("unchecked")

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/ConfigNodeContainer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/ConfigNodeContainer.java
@@ -14,16 +14,19 @@ import java.util.Objects;
 public final class ConfigNodeContainer {
     private final ConfigNode configNode;
     private final ConfigSource source;
+    private final Tags tags;
 
     /**
      * Constructor to hold a ConfigNode and a id.
      *
      * @param configNode node to hold
      * @param source     the source of the configs
+     * @param tags       tags associated with the source.
      */
-    public ConfigNodeContainer(ConfigNode configNode, ConfigSource source) {
+    public ConfigNodeContainer(ConfigNode configNode, ConfigSource source, Tags tags) {
         this.configNode = configNode;
         this.source = source;
+        this.tags = tags;
     }
 
     /**
@@ -50,7 +53,7 @@ public final class ConfigNodeContainer {
      * @return Tags
      */
     public Tags getTags() {
-        return source.getTags();
+        return tags;
     }
 
     /**
@@ -60,7 +63,7 @@ public final class ConfigNodeContainer {
      * @return true if the tags for the Config Node match the input
      */
     public boolean matchesTags(Tags match) {
-        return source.getTags().equals(match);
+        return tags.equals(match);
     }
 
     @Override
@@ -72,11 +75,11 @@ public final class ConfigNodeContainer {
             return false;
         }
         ConfigNodeContainer that = (ConfigNodeContainer) o;
-        return Objects.equals(configNode, that.configNode) && Objects.equals(source, that.source);
+        return Objects.equals(configNode, that.configNode) && Objects.equals(source, that.source) && Objects.equals(tags, that.tags);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(configNode, source);
+        return Objects.hash(configNode, source, tags);
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/ConfigLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/ConfigLoader.java
@@ -3,7 +3,7 @@ package org.github.gestalt.config.loader;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.utils.GResultOf;
 
 import java.util.List;
@@ -50,5 +50,5 @@ public interface ConfigLoader {
      * @return the validated config node.
      * @throws GestaltException any exceptions
      */
-    GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException;
+    GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage source) throws GestaltException;
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoader.java
@@ -8,7 +8,7 @@ import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.parser.ConfigParser;
 import org.github.gestalt.config.parser.MapConfigParser;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.EnvironmentConfigSource;
 import org.github.gestalt.config.utils.GResultOf;
 import org.github.gestalt.config.utils.Pair;
@@ -56,8 +56,9 @@ public final class EnvironmentVarsLoader implements ConfigLoader {
     }
 
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
         List<Pair<String, String>> configs;
+        var source = sourcePackage.getConfigSource();
         if (source.hasList()) {
             configs = source.loadList();
         } else {
@@ -65,11 +66,11 @@ public final class EnvironmentVarsLoader implements ConfigLoader {
         }
 
         if (configs.isEmpty()) {
-            return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source)));
+            return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source, sourcePackage.getTags())));
         }
 
         GResultOf<ConfigNode> loadedNode = ConfigCompiler.analyze(source.failOnErrors(), lexer, parser, configs);
 
-        return loadedNode.mapWithError((result) -> List.of(new ConfigNodeContainer(result, source)));
+        return loadedNode.mapWithError((result) -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
@@ -8,7 +8,7 @@ import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.parser.ConfigParser;
 import org.github.gestalt.config.parser.MapConfigParser;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.utils.GResultOf;
 import org.github.gestalt.config.utils.Pair;
@@ -55,8 +55,9 @@ public final class MapConfigLoader implements ConfigLoader {
     }
 
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
         List<Pair<String, String>> configs;
+        var source = sourcePackage.getConfigSource();
         if (source.hasList()) {
             configs = source.loadList();
         } else {
@@ -64,11 +65,11 @@ public final class MapConfigLoader implements ConfigLoader {
         }
 
         if (configs.isEmpty()) {
-            return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source)));
+            return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source, sourcePackage.getTags())));
         }
 
         GResultOf<ConfigNode> loadedNode = ConfigCompiler.analyze(source.failOnErrors(), lexer, parser, configs);
 
-        return loadedNode.mapWithError((result) -> List.of(new ConfigNodeContainer(result, source)));
+        return loadedNode.mapWithError((result) -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformerOld.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformerOld.java
@@ -14,6 +14,8 @@ import org.github.gestalt.config.utils.GResultOf;
 @ConfigPriority(100)
 @Deprecated(since = "0.20.1", forRemoval = true)
 public final class EnvironmentVariablesTransformerOld implements Transformer {
+    private static final System.Logger logger = System.getLogger(EnvironmentVariablesTransformerOld.class.getName());
+
     @Override
     public String name() {
         return "envVar";
@@ -26,6 +28,10 @@ public final class EnvironmentVariablesTransformerOld implements Transformer {
         } else if (System.getenv(key) == null) {
             return GResultOf.errors(new ValidationError.NoEnvironmentVariableFoundPostProcess(path, key));
         } else {
+            // this class has been depricated a while, however since it is not directly exposed, no one would know that.
+            // start logging warnings, so we can comfortably delete it later.
+            logger.log(System.Logger.Level.WARNING,
+                "String substitutions using \"envVar\" is deprecated for removal, please use \"env\"");
             return GResultOf.result(System.getenv(key));
         }
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/ConfigReloadListener.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/ConfigReloadListener.java
@@ -1,10 +1,10 @@
 package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 
 /**
- * Listener for when configs need to reloads.
+ * Listener for when configs need to reloads. This is for use internally, end users most likely should not use this.
  *
  * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
  */
@@ -15,5 +15,5 @@ public interface ConfigReloadListener {
      * @param source the source we should reload.
      * @throws GestaltException any exceptions
      */
-    void reload(ConfigSource source) throws GestaltException;
+    void reload(ConfigSourcePackage source) throws GestaltException;
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/ConfigReloadStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/ConfigReloadStrategy.java
@@ -2,7 +2,7 @@ package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,8 +25,11 @@ public abstract class ConfigReloadStrategy {  ///NOPMD
 
     /**
      * The source we are listening for a reload.
+     *
+     * note: i dont love that the ConfigReloadStrategy needs the ConfigSourcePackage since it is a circular reference.
+     *     As the ConfigSourcePackage holds a list of ConfigReloadStrategy. Use the Source builders to manage this.
      */
-    protected ConfigSource source;
+    protected ConfigSourcePackage source;
 
     /**
      * Protected constructor for the ConfigReloadStrategy. So end users cant create this class, only inherit it.
@@ -40,26 +43,30 @@ public abstract class ConfigReloadStrategy {  ///NOPMD
      *
      * @param source source we are listening for a reload
      */
-    protected ConfigReloadStrategy(ConfigSource source) {
+    protected ConfigReloadStrategy(ConfigSourcePackage source) {
         this.source = source;
     }
 
     /**
      * Get the source this reload strategy should apply to.
      *
+     *
      * @return the source this reload strategy should apply to.
      */
-    public ConfigSource getSource() {
+    public ConfigSourcePackage getSource() {
         return source;
     }
 
     /**
      * set the source this reload strategy should apply to.
      *
+     * note: i dont love that the ConfigReloadStrategy needs the ConfigSourcePackage since it is a circular reference.
+     *     As the ConfigSourcePackage holds a list of ConfigReloadStrategy. Use the Source builders to manage this.
+     *
      * @param source the source this reload strategy should apply to.
-     * @throws GestaltConfigurationException if there is an exception setting the source
+     * @throws GestaltConfigurationException if there are any errors applying the source
      */
-    public void setSource(ConfigSource source) throws GestaltConfigurationException {
+    public void setSource(ConfigSourcePackage source) throws GestaltConfigurationException {
         this.source = source;
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/FileChangeReloadStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/FileChangeReloadStrategy.java
@@ -2,7 +2,7 @@ package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.FileConfigSource;
 
 import java.io.IOException;
@@ -52,8 +52,11 @@ public final class FileChangeReloadStrategy extends ConfigReloadStrategy {
      *
      * @param source the source to watch for reload
      * @throws GestaltConfigurationException if this is not a file source or other errors.
+     * @deprecated Do not add the source directly, but use the source builders then add the reload strategy to the builder
+     *     {@link org.github.gestalt.config.builder.SourceBuilder#addConfigReloadStrategy(ConfigReloadStrategy)}
      */
-    public FileChangeReloadStrategy(ConfigSource source) throws GestaltConfigurationException {
+    @Deprecated(since = "0.26.0", forRemoval = true)
+    public FileChangeReloadStrategy(ConfigSourcePackage source) throws GestaltConfigurationException {
         this(source, Executors.newSingleThreadExecutor());
     }
 
@@ -64,19 +67,22 @@ public final class FileChangeReloadStrategy extends ConfigReloadStrategy {
      * @param source   the source to watch for reload
      * @param executor ExecutorService to get thread from.
      * @throws GestaltConfigurationException if this is not a file source or other errors.
+     * @deprecated Do not add the source directly, but use the source builders then add the reload strategy to the builder
+     *      {@link org.github.gestalt.config.builder.SourceBuilder#addConfigReloadStrategy(ConfigReloadStrategy)}
      */
-    public FileChangeReloadStrategy(ConfigSource source, ExecutorService executor) throws GestaltConfigurationException {
+    @Deprecated(since = "0.26.0", forRemoval = true)
+    public FileChangeReloadStrategy(ConfigSourcePackage source, ExecutorService executor) throws GestaltConfigurationException {
         super(source);
         this.executor = executor;
-        if (source != null && !(source instanceof FileConfigSource)) {
+        if (source != null && !(source.getConfigSource() instanceof FileConfigSource)) {
             throw new GestaltConfigurationException("Unable to add a File Change reload strategy to a non file source " + source);
         }
         setupWatcherTask();
     }
 
     @Override
-    public void setSource(ConfigSource source) throws GestaltConfigurationException {
-        if (!(source instanceof FileConfigSource)) {
+    public void setSource(ConfigSourcePackage source) throws GestaltConfigurationException {
+        if (!(source.getConfigSource() instanceof FileConfigSource)) {
             throw new GestaltConfigurationException("Unable to add a File Change reload strategy to a non file source " + source);
         }
         this.source = source;
@@ -85,7 +91,7 @@ public final class FileChangeReloadStrategy extends ConfigReloadStrategy {
 
     private void setupWatcherTask() throws GestaltConfigurationException {
         if (source != null) {
-            path = ((FileConfigSource) source).getPath();
+            path = ((FileConfigSource) source.getConfigSource()).getPath();
             try {
                 if (watcher != null) {
                     watcher.close();

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/ManualConfigReloadStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/ManualConfigReloadStrategy.java
@@ -1,7 +1,7 @@
 package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 
 /**
  * Reloads a source when called.
@@ -20,8 +20,11 @@ public final class ManualConfigReloadStrategy extends ConfigReloadStrategy {
      * Constructor for ManualConfigReloadStrategy.
      *
      * @param source the config source to reload
+     * @deprecated Do not add the source directly, but use the source builders then add the reload strategy to the builder
+     *      {@link org.github.gestalt.config.builder.SourceBuilder#addConfigReloadStrategy(ConfigReloadStrategy)}
      */
-    public ManualConfigReloadStrategy(ConfigSource source) {
+    @Deprecated(since = "0.26.0", forRemoval = true)
+    public ManualConfigReloadStrategy(ConfigSourcePackage source) {
         super(source);
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/reload/TimedConfigReloadStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/reload/TimedConfigReloadStrategy.java
@@ -1,7 +1,7 @@
 package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltException;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -35,8 +35,11 @@ public final class TimedConfigReloadStrategy extends ConfigReloadStrategy {
      *
      * @param source      the config source to reload
      * @param reloadDelay how often to reload the config source
+     * @deprecated Do not add the source directly, but use the source builders then add the reload strategy to the builder
+     *      {@link org.github.gestalt.config.builder.SourceBuilder#addConfigReloadStrategy(ConfigReloadStrategy)}.
      */
-    public TimedConfigReloadStrategy(ConfigSource source, Duration reloadDelay) {
+    @Deprecated(since = "0.26.0", forRemoval = true)
+    public TimedConfigReloadStrategy(ConfigSourcePackage source, Duration reloadDelay) {
         super(source);
         Objects.requireNonNull(reloadDelay, "Reload Delay must be set for a TimedConfigReloadStrategy");
         this.reloadDelay = reloadDelay;
@@ -50,7 +53,8 @@ public final class TimedConfigReloadStrategy extends ConfigReloadStrategy {
                 try {
                     reload();
                 } catch (GestaltException e) {
-                    logger.log(System.Logger.Level.ERROR, "Exception reloading source " + source.name() + ", exception " + e, e);
+                    logger.log(System.Logger.Level.ERROR,
+                        "Exception reloading source " + source.getConfigSource().name() + ", exception " + e, e);
                 }
             }
         }, reloadDelay.toMillis(), reloadDelay.toMillis());

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSource.java
@@ -35,7 +35,9 @@ public final class ClassPathConfigSource implements ConfigSource {
      * @param resource name of the resource to load from the class path.
      * @param tags     tags associated with the source
      * @throws GestaltException any exceptions
+     * @deprecated tags should be
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public ClassPathConfigSource(String resource, Tags tags) throws GestaltException {
         this.resource = resource;
         if (resource == null) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/ClassPathConfigSourceBuilder.java
@@ -52,6 +52,6 @@ public final class ClassPathConfigSourceBuilder extends SourceBuilder<ClassPathC
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new ClassPathConfigSource(resource, tags));
+        return buildPackage(new ClassPathConfigSource(resource));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/ConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/ConfigSource.java
@@ -77,7 +77,9 @@ public interface ConfigSource {
      * A source can have a set of tags that apply to all nodes in the source.
      *
      * @return tags assigned to the source
+     * @deprecated tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     Tags getTags();
 
     /**

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/ConfigSourcePackage.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/ConfigSourcePackage.java
@@ -1,9 +1,13 @@
 package org.github.gestalt.config.source;
 
 import org.github.gestalt.config.reload.ConfigReloadStrategy;
+import org.github.gestalt.config.tag.Tag;
+import org.github.gestalt.config.tag.Tags;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Container that holds the Config Source as well as the configReloadStrategies.
@@ -14,15 +18,19 @@ public class ConfigSourcePackage {
     private final ConfigSource configSource;
     private final List<ConfigReloadStrategy> configReloadStrategies;
 
+    private final Tags tags;
+
     /**
      * Constructor for the ConfigSourcePackage that requires the config source and the configReloadStrategies.
      *
      * @param configSource           the config source
      * @param configReloadStrategies the configReloadStrategies
+     * @param tags                   the tags associated with the config source package
      */
-    public ConfigSourcePackage(ConfigSource configSource, List<ConfigReloadStrategy> configReloadStrategies) {
+    public ConfigSourcePackage(ConfigSource configSource, List<ConfigReloadStrategy> configReloadStrategies, Tags tags) {
         this.configSource = configSource;
         this.configReloadStrategies = configReloadStrategies;
+        this.tags = tags;
     }
 
     /**
@@ -41,6 +49,22 @@ public class ConfigSourcePackage {
      */
     public List<ConfigReloadStrategy> getConfigReloadStrategies() {
         return configReloadStrategies;
+    }
+
+    /**
+     * Get the tags associated with the config source.
+     *
+     * @return  the tags associated with the config source
+     */
+    public Tags getTags() {
+
+        // remove this once we remove the tags from the config source.
+        Set<Tag> combinedTags = new HashSet<>();
+        if(configSource.getTags() != null) {
+            combinedTags.addAll(configSource.getTags().getTags());
+        }
+        combinedTags.addAll(tags.getTags());
+        return Tags.of(combinedTags);
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
@@ -97,8 +97,27 @@ public final class EnvironmentConfigSource implements ConfigSource {
      * @param removePrefix       If you should remove the prefix from the output
      * @param failOnErrors       Do not fail on errors while loading Env Vars since they
      *                           are often uncontrolled and may not follow expected conventions of this library.
-     * @param tags               set of tags associated with this source.
      */
+    public EnvironmentConfigSource(String prefix, boolean ignoreCaseOnPrefix, boolean removePrefix, boolean failOnErrors) {
+        this.failOnErrors = failOnErrors;
+        this.prefix = prefix;
+        this.ignoreCaseOnPrefix = ignoreCaseOnPrefix;
+        this.removePrefix = removePrefix;
+        this.tags = Tags.of();
+    }
+
+    /**
+     * Specify if you want to only parse the Environment variables that have a prefix.
+     *
+     * @param prefix             only use the Environment variables that have a prefix.
+     * @param ignoreCaseOnPrefix Ignore the case on matching the prefix
+     * @param removePrefix       If you should remove the prefix from the output
+     * @param failOnErrors       Do not fail on errors while loading Env Vars since they
+     *                           are often uncontrolled and may not follow expected conventions of this library.
+     * @param tags               set of tags associated with this source.
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
+     */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public EnvironmentConfigSource(String prefix, boolean ignoreCaseOnPrefix, boolean removePrefix, boolean failOnErrors, Tags tags) {
         this.failOnErrors = failOnErrors;
         this.prefix = prefix;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSourceBuilder.java
@@ -122,6 +122,6 @@ public final class EnvironmentConfigSourceBuilder extends SourceBuilder<Environm
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new EnvironmentConfigSource(prefix, ignoreCaseOnPrefix, removePrefix, failOnErrors, tags));
+        return buildPackage(new EnvironmentConfigSource(prefix, ignoreCaseOnPrefix, removePrefix, failOnErrors));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/FileConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/FileConfigSource.java
@@ -41,7 +41,9 @@ public final class FileConfigSource implements ConfigSource {
      * @param file where to load the File with the configuration
      * @param tags tags associated with the source
      * @throws GestaltException any exceptions.
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public FileConfigSource(File file, Tags tags) throws GestaltException {
         this(Objects.requireNonNull(file, "file can not be null").toPath(), tags);
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/FileConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/FileConfigSourceBuilder.java
@@ -78,6 +78,6 @@ public final class FileConfigSourceBuilder extends SourceBuilder<FileConfigSourc
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new FileConfigSource(path, tags));
+        return buildPackage(new FileConfigSource(path));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/KubernetesSecretConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/KubernetesSecretConfigSource.java
@@ -46,7 +46,9 @@ public final class KubernetesSecretConfigSource implements ConfigSource {
      * @param file where to load the directory with the configuration
      * @param tags tags associated with the source
      * @throws GestaltException any exceptions.
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public KubernetesSecretConfigSource(File file, Tags tags) throws GestaltException {
         this(Objects.requireNonNull(file, "Kubernetes Secret file can not be null").toPath(), tags);
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/KubernetesSecretConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/KubernetesSecretConfigSourceBuilder.java
@@ -82,6 +82,6 @@ public final class KubernetesSecretConfigSourceBuilder
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new KubernetesSecretConfigSource(path, tags));
+        return buildPackage(new KubernetesSecretConfigSource(path));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/MapConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/MapConfigSource.java
@@ -45,7 +45,9 @@ public final class MapConfigSource implements ConfigSource {
      *
      * @param customConfig map of configs.
      * @param tags         tags associated with the source
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public MapConfigSource(Map<String, String> customConfig, Tags tags) {
         Objects.requireNonNull(customConfig, "Custom map must not be null");
         this.customConfig = customConfig;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/MapConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/MapConfigSourceBuilder.java
@@ -71,6 +71,6 @@ public final class MapConfigSourceBuilder extends SourceBuilder<MapConfigSourceB
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new MapConfigSource(customConfig, tags));
+        return buildPackage(new MapConfigSource(customConfig));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/StringConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/StringConfigSource.java
@@ -55,7 +55,9 @@ public final class StringConfigSource implements ConfigSource {
      * @param format format for the string.
      * @param tags   tags associated with this source
      * @throws GestaltException any exception
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public StringConfigSource(String config, String format, Tags tags) throws GestaltException {
         this.config = config;
         if (config == null) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/StringConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/StringConfigSourceBuilder.java
@@ -86,6 +86,6 @@ public final class StringConfigSourceBuilder extends SourceBuilder<StringConfigS
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new StringConfigSource(config, format, tags));
+        return buildPackage(new StringConfigSource(config, format));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSource.java
@@ -54,7 +54,9 @@ public final class SystemPropertiesConfigSource implements ConfigSource {
      * constructor for SystemPropertiesConfigSource.
      *
      * @param tags tags associated with the source
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public SystemPropertiesConfigSource(Tags tags) {
         this(false, tags);
     }
@@ -65,7 +67,9 @@ public final class SystemPropertiesConfigSource implements ConfigSource {
      * @param failOnErrors treat Errors while loading as warnings since System Properties
      *                     are often uncontrolled and may not follow expected conventions of this library.
      * @param tags         tags associated with the source
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public SystemPropertiesConfigSource(boolean failOnErrors, Tags tags) {
         this.failOnErrors = failOnErrors;
         this.tags = tags;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSourceBuilder.java
@@ -53,6 +53,6 @@ public final class SystemPropertiesConfigSourceBuilder
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new SystemPropertiesConfigSource(failOnErrors, tags));
+        return buildPackage(new SystemPropertiesConfigSource(failOnErrors));
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/URLConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/URLConfigSource.java
@@ -41,7 +41,9 @@ public final class URLConfigSource implements ConfigSource {
      * @param sourceURL source URL
      * @param tags      tags associated with the source
      * @throws GestaltException any exceptions
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public URLConfigSource(String sourceURL, Tags tags) throws GestaltException {
         this.sourceURL = sourceURL;
         if (this.sourceURL == null) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/URLConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/URLConfigSourceBuilder.java
@@ -52,6 +52,6 @@ public final class URLConfigSourceBuilder extends SourceBuilder<URLConfigSourceB
 
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new URLConfigSource(sourceURL, tags));
+        return buildPackage(new URLConfigSource(sourceURL));
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/builder/GestaltBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/builder/GestaltBuilderTest.java
@@ -858,7 +858,7 @@ class GestaltBuilderTest {
         }
 
         @Override
-        public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+        public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage source) throws GestaltException {
             return null;
         }
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/builder/SourceBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/builder/SourceBuilderTest.java
@@ -38,8 +38,8 @@ public class SourceBuilderTest {
 
     @Test
     public void testBuilderConfigSourcePackageCreation() throws GestaltException, IOException {
-        var source = new StringConfigSource("abc=def", "properties", Tags.environment("dev"));
-        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of());
+        var source = new StringConfigSource("abc=def", "properties");
+        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of(), Tags.environment("dev"));
 
         var built = sourceBuilder.setSource("abc=def")
             .setTags(Tags.environment("dev"))
@@ -47,12 +47,42 @@ public class SourceBuilderTest {
         assertEquals(new String(configSourcePackage.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()),
             new String(built.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()));
         assertEquals(configSourcePackage.getConfigReloadStrategies(), built.getConfigReloadStrategies());
+        assertEquals(configSourcePackage.getTags(), built.getTags());
+    }
+
+    @Test
+    public void testBuilderConfigSourceTagsOnSource() throws GestaltException, IOException {
+        var source = new StringConfigSource("abc=def", "properties", Tags.environment("dev"));
+        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of(), Tags.of());
+
+        var built = sourceBuilder.setSource("abc=def")
+            .setTags(Tags.environment("dev"))
+            .build();
+        assertEquals(new String(configSourcePackage.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()),
+            new String(built.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()));
+        assertEquals(configSourcePackage.getConfigReloadStrategies(), built.getConfigReloadStrategies());
+        assertEquals(configSourcePackage.getTags(), built.getTags());
+    }
+
+    @Test
+    public void testBuilderConfigSourceTagsOnBoth() throws GestaltException, IOException {
+        var source = new StringConfigSource("abc=def", "properties", Tags.environment("dev"));
+        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of(), Tags.profile("test"));
+
+        var built = sourceBuilder.setSource("abc=def")
+            .setTags(Tags.environment("dev"))
+            .addTags(Tags.profile("test"))
+            .build();
+        assertEquals(new String(configSourcePackage.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()),
+            new String(built.getConfigSource().loadStream().readAllBytes(), Charset.defaultCharset()));
+        assertEquals(configSourcePackage.getConfigReloadStrategies(), built.getConfigReloadStrategies());
+        assertEquals(configSourcePackage.getTags(), built.getTags());
     }
 
     @Test
     public void testConfigSourcePackageCreation() throws GestaltException {
         var source = new StringConfigSource("abc=def", "properties");
-        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of());
+        ConfigSourcePackage configSourcePackage = new ConfigSourcePackage(source, List.of(), Tags.of());
         assertEquals(source, configSourcePackage.getConfigSource());
         assertEquals(0, configSourcePackage.getConfigReloadStrategies().size());
     }
@@ -189,7 +219,7 @@ public class SourceBuilderTest {
 
         @Override
         public ConfigSourcePackage build() throws GestaltException {
-            return buildPackage(new StringConfigSource(text, "properties", tags));
+            return buildPackage(new StringConfigSource(text, "properties"));
         }
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/entity/ConfigNodeContainerTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/entity/ConfigNodeContainerTest.java
@@ -33,7 +33,7 @@ class ConfigNodeContainerTest {
         root1Node.put("admin", new ArrayNode(List.of(arrayNode)));
         ConfigNode root1 = new MapNode(root1Node);
 
-        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource());
+        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(), Tags.of());
 
         Assertions.assertEquals(root1, cfgNode.getConfigNode());
     }
@@ -55,13 +55,13 @@ class ConfigNodeContainerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         UUID id = UUID.randomUUID();
-        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id));
+        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id), Tags.of());
 
         Assertions.assertEquals(id, cfgNode.getSource().id());
     }
 
     @Test
-    void testEquals() {
+    void testEquals() throws GestaltException {
         ConfigNode[] arrayNode = new ConfigNode[2];
         arrayNode[0] = new LeafNode("John");
         arrayNode[1] = new LeafNode("Steve");
@@ -91,13 +91,15 @@ class ConfigNodeContainerTest {
         UUID id2 = UUID.randomUUID();
 
         ConfigNode root1 = new MapNode(root1Node);
-        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id));
-        ConfigNodeContainer cfgNode2 = new ConfigNodeContainer(root2, new TestSource(id2));
-        ConfigNodeContainer cfgNode3 = new ConfigNodeContainer(root1, new TestSource(id));
+        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id), Tags.of());
+        ConfigNodeContainer cfgNode2 = new ConfigNodeContainer(root2, new TestSource(id2), Tags.of());
+        ConfigNodeContainer cfgNode3 = new ConfigNodeContainer(root1, new TestSource(id), Tags.of());
+        ConfigNodeContainer cfgNode4 = new ConfigNodeContainer(root1, new TestSource(id), Tags.of("test", "data"));
 
         Assertions.assertEquals(cfgNode, cfgNode);
         Assertions.assertEquals(cfgNode, cfgNode3);
         Assertions.assertNotEquals(cfgNode, cfgNode2);
+        Assertions.assertNotEquals(cfgNode3, cfgNode4);
         Assertions.assertNotEquals(cfgNode, null);
         Assertions.assertNotEquals(cfgNode, 3);
     }
@@ -120,7 +122,7 @@ class ConfigNodeContainerTest {
 
         UUID id = UUID.fromString("9d4e9197-5898-45e6-9056-a4a29d2c2a64");
 
-        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id, Tags.of("toy", "ball")));
-        Assertions.assertEquals(-692160029, cfgNode.hashCode());
+        ConfigNodeContainer cfgNode = new ConfigNodeContainer(root1, new TestSource(id), Tags.of("toy", "ball"));
+        Assertions.assertEquals(-179624288, cfgNode.hashCode());
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/CompilerConfigTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/CompilerConfigTest.java
@@ -4,8 +4,10 @@ import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.parser.MapConfigParser;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.TestMapConfigSource;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.GResultOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,8 +29,9 @@ class CompilerConfigTest {
         // create our class to be tested
         MapConfigLoader mapConfigLoader = new MapConfigLoader();
 
+        var source = new MapConfigSource(data);
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new MapConfigSource(data));
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -53,8 +56,9 @@ class CompilerConfigTest {
         MapConfigLoader mapConfigLoader
             = new MapConfigLoader(new PathLexer(".", "^((?<name>\\w+)(?<array>\\[(?<index>\\d*)])?)$"), new MapConfigParser());
 
+        var source = new MapConfigSource(data);
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new MapConfigSource(data));
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
@@ -77,8 +81,9 @@ class CompilerConfigTest {
         MapConfigLoader mapConfigLoader
             = new MapConfigLoader(new PathLexer(".", "^((?<name>\\w+)(?<array>\\[(?<index>\\d*)])?)$"), new MapConfigParser());
 
+        var source = new MapConfigSourceWarn(data, false);
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new MapConfigSourceWarn(data, false));
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertTrue(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
@@ -106,8 +111,9 @@ class CompilerConfigTest {
         // create our class to be tested
         MapConfigLoader mapConfigLoader = new MapConfigLoader();
 
+        var source = new MapConfigSource(data);
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new MapConfigSource(data));
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(results.hasResults());
         Assertions.assertTrue(results.hasErrors());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
@@ -10,6 +10,7 @@ import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.parser.ConfigParser;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.StringConfigSource;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.token.ObjectToken;
@@ -61,12 +62,13 @@ class EnvironmentLoaderTest {
         // mock the source so we return our test data stream.
         Mockito.when(source.hasList()).thenReturn(true);
         Mockito.when(source.loadList()).thenReturn(data);
+        Mockito.when(source.getTags()).thenReturn(Tags.of());
 
         // create our class to be tested
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+        var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -121,13 +123,13 @@ class EnvironmentLoaderTest {
         // mock the source so we return our test data stream.
         Mockito.when(source.hasList()).thenReturn(true);
         Mockito.when(source.loadList()).thenReturn(data);
-        Mockito.when(source.getTags()).thenReturn(Tags.of("toy", "ball"));
+        Mockito.when(source.getTags()).thenReturn(Tags.of());
 
         // create our class to be tested
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+        var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of("toy", "ball")));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -192,7 +194,7 @@ class EnvironmentLoaderTest {
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+        var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
@@ -238,13 +240,14 @@ class EnvironmentLoaderTest {
         Mockito.when(source.loadList()).thenReturn(data);
         Mockito.when(source.name()).thenReturn("mock");
         Mockito.when(source.failOnErrors()).thenReturn(false);
+        Mockito.when(source.getTags()).thenReturn(Tags.of());
 
         // create our class to be tested
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
         try {
-            GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+            var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
             Assertions.assertTrue(results.hasResults());
             Assertions.assertTrue(results.hasErrors());
@@ -295,12 +298,13 @@ class EnvironmentLoaderTest {
         // mock the source so we return our test data stream.
         Mockito.when(source.hasList()).thenReturn(true);
         Mockito.when(source.loadList()).thenReturn(data);
+        Mockito.when(source.getTags()).thenReturn(Tags.of());
 
         // create our class to be tested
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+        var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
 
@@ -344,7 +348,8 @@ class EnvironmentLoaderTest {
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GestaltException e = Assertions.assertThrows(GestaltException.class, () -> environmentVarsLoader.loadSource(source));
+        GestaltException e = Assertions.assertThrows(GestaltException.class,
+            () -> environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of())));
         Assertions.assertEquals("Config source: mock does not have a list to load.", e.getMessage());
 
 
@@ -372,7 +377,8 @@ class EnvironmentLoaderTest {
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GestaltException e = Assertions.assertThrows(GestaltException.class, () -> environmentVarsLoader.loadSource(source));
+        GestaltException e = Assertions.assertThrows(GestaltException.class,
+            () -> environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of())));
         Assertions.assertEquals("bad stream", e.getMessage());
 
         // verify we get the correct number of calls and capture the parsers arguments.
@@ -392,7 +398,8 @@ class EnvironmentLoaderTest {
         StringConfigSource source = new StringConfigSource(
             "path : ${DB_IDLETIMEOUT}", "conf");
 
-        GestaltException e = Assertions.assertThrows(GestaltException.class, () -> environmentVarsLoader.loadSource(source));
+        GestaltException e = Assertions.assertThrows(GestaltException.class,
+            () -> environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of())));
         Assertions.assertEquals("Config source: String format: conf does not have a list to load.", e.getMessage());
     }
 
@@ -415,7 +422,7 @@ class EnvironmentLoaderTest {
         EnvironmentVarsLoader environmentVarsLoader = new EnvironmentVarsLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = environmentVarsLoader.loadSource(source);
+        var results = environmentVarsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapConfigLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapConfigLoaderTest.java
@@ -9,6 +9,7 @@ import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.parser.ConfigParser;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
 import org.github.gestalt.config.tag.Tags;
@@ -64,7 +65,7 @@ class MapConfigLoaderTest {
         MapConfigLoader mapConfigLoader = new MapConfigLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -119,13 +120,12 @@ class MapConfigLoaderTest {
         // mock the source so we return our test data stream.
         Mockito.when(source.hasList()).thenReturn(true);
         Mockito.when(source.loadList()).thenReturn(data);
-        Mockito.when(source.getTags()).thenReturn(Tags.of("toy", "ball"));
 
         // create our class to be tested
         MapConfigLoader mapConfigLoader = new MapConfigLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(source);
+        var results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of("toy", "ball")));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -189,7 +189,7 @@ class MapConfigLoaderTest {
         MapConfigLoader mapConfigLoader = new MapConfigLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
 
@@ -233,7 +233,7 @@ class MapConfigLoaderTest {
         MapConfigLoader mapConfigLoader = new MapConfigLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
 
@@ -278,7 +278,7 @@ class MapConfigLoaderTest {
 
         // run the code under test.
         try {
-            mapConfigLoader.loadSource(source);
+            mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not hit this");
         } catch (GestaltException e) {
             Assertions.assertEquals("Config source: mock does not have a list to load.", e.getMessage());
@@ -308,7 +308,7 @@ class MapConfigLoaderTest {
 
         // run the code under test.
         try {
-            mapConfigLoader.loadSource(source);
+            mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not hit this");
         } catch (GestaltException e) {
             Assertions.assertEquals("bad stream", e.getMessage());
@@ -330,8 +330,9 @@ class MapConfigLoaderTest {
         // create our class to be tested
         MapConfigLoader mapConfigLoader = new MapConfigLoader();
 
+        var source = new MapConfigSource(data);
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new MapConfigSource(data));
+        GResultOf<List<ConfigNodeContainer>> results = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
     }
@@ -345,7 +346,7 @@ class MapConfigLoaderTest {
         MapConfigLoader mapConfigLoader = new MapConfigLoader();
 
         try {
-            mapConfigLoader.loadSource(source);
+            mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Config source: String format: conf does not have a list to load.", e.getMessage());
@@ -359,7 +360,7 @@ class MapConfigLoaderTest {
 
         MapConfigLoader mapConfigLoader = new MapConfigLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = mapConfigLoader.loadSource(source);
+        var resultContainer = mapConfigLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
@@ -9,6 +9,7 @@ import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.parser.ConfigParser;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
 import org.github.gestalt.config.tag.Tags;
@@ -69,7 +70,7 @@ class PropertyLoaderTest {
         PropertyLoader propsLoader = new PropertyLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -123,13 +124,12 @@ class PropertyLoaderTest {
         // mock the source so we return our test data stream.
         Mockito.when(source.hasStream()).thenReturn(true);
         Mockito.when(source.loadStream()).thenReturn(inputStream);
-        Mockito.when(source.getTags()).thenReturn(Tags.of("toy", "ball"));
 
         // create our class to be tested
         PropertyLoader propsLoader = new PropertyLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(source);
+        var results = propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of("toy", "ball")));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertFalse(results.hasErrors());
 
@@ -192,7 +192,7 @@ class PropertyLoaderTest {
         PropertyLoader propsLoader = new PropertyLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue("empty path provided".equals(results.getErrors().get(0).description()) ||
             "Unable to tokenize element name for path: db.name".equals(results.getErrors().get(0).description()));
         Assertions.assertTrue("empty path provided".equals(results.getErrors().get(1).description()) ||
@@ -233,7 +233,7 @@ class PropertyLoaderTest {
         PropertyLoader propsLoader = new PropertyLoader(lexer, parser);
 
         // run the code under test.
-        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> results = propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertTrue(results.hasResults());
         Assertions.assertTrue(results.hasErrors());
 
@@ -279,7 +279,7 @@ class PropertyLoaderTest {
 
         // run the code under test.
         try {
-            propsLoader.loadSource(source);
+            propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not hit this");
         } catch (GestaltException e) {
             Assertions.assertEquals("Config source: mock does not have a stream to load.", e.getMessage());
@@ -309,7 +309,7 @@ class PropertyLoaderTest {
 
         // run the code under test.
         try {
-            propsLoader.loadSource(source);
+            propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not hit this");
         } catch (GestaltException e) {
             Assertions.assertEquals("bad stream", e.getMessage());
@@ -338,7 +338,7 @@ class PropertyLoaderTest {
 
         // run the code under test.
         try {
-            propsLoader.loadSource(source);
+            propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not hit this");
         } catch (GestaltException e) {
             Assertions.assertEquals("Exception loading source: mock", e.getMessage());
@@ -362,7 +362,7 @@ class PropertyLoaderTest {
         PropertyLoader propsLoader = new PropertyLoader(lexer, parser);
 
         try {
-            propsLoader.loadSource(source);
+            propsLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Config source: mapConfig does not have a stream to load.", e.getMessage());
@@ -376,7 +376,7 @@ class PropertyLoaderTest {
 
         PropertyLoader propertyLoader = new PropertyLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = propertyLoader.loadSource(source);
+        var resultContainer = propertyLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeManagerTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeManagerTest.java
@@ -37,7 +37,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -69,7 +69,7 @@ class ConfigNodeManagerTest {
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -100,7 +100,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -118,7 +118,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -153,7 +153,7 @@ class ConfigNodeManagerTest {
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -172,7 +172,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         GResultOf<ConfigNode> results2 =
-            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -207,7 +207,7 @@ class ConfigNodeManagerTest {
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -226,7 +226,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         GResultOf<ConfigNode> results2 =
-            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(Tags.of("toy", "car"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of("toy", "car")));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -271,7 +271,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -297,7 +297,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -342,7 +342,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -372,7 +372,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -421,7 +421,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -453,7 +453,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -506,7 +506,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -524,7 +524,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -546,7 +546,7 @@ class ConfigNodeManagerTest {
         rootNode3.put("admin", new ArrayNode(Arrays.asList(arrayNode3)));
         ConfigNode root3 = new MapNode(rootNode3);
 
-        GResultOf<ConfigNode> results3 = configNodeManager.addNode(new ConfigNodeContainer(root3, new TestSource()));
+        GResultOf<ConfigNode> results3 = configNodeManager.addNode(new ConfigNodeContainer(root3, new TestSource(), Tags.of()));
         Assertions.assertFalse(results3.hasErrors());
         Assertions.assertTrue(results3.hasResults());
         Assertions.assertNotNull(results3.results());
@@ -581,7 +581,7 @@ class ConfigNodeManagerTest {
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -600,7 +600,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         GResultOf<ConfigNode> results2 =
-            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -623,7 +623,7 @@ class ConfigNodeManagerTest {
         ConfigNode root3 = new MapNode(rootNode3);
 
         GResultOf<ConfigNode> results3 =
-            configNodeManager.addNode(new ConfigNodeContainer(root3, new TestSource()));
+            configNodeManager.addNode(new ConfigNodeContainer(root3, new TestSource(), Tags.of()));
         Assertions.assertFalse(results3.hasErrors());
         Assertions.assertTrue(results3.hasResults());
         Assertions.assertNotNull(results3.results());
@@ -656,7 +656,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -670,7 +670,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new LeafNode("test"));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
 
@@ -704,7 +704,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -722,7 +722,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -758,7 +758,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -779,7 +779,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -818,7 +818,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -836,7 +836,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -874,7 +874,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -896,7 +896,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -935,7 +935,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -953,7 +953,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -991,7 +991,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1012,7 +1012,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1048,7 +1048,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1069,7 +1069,7 @@ class ConfigNodeManagerTest {
         rootNode2.put("admin", new ArrayNode(Arrays.asList(arrayNode2)));
         ConfigNode root2 = new MapNode(rootNode2);
 
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource()));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
         Assertions.assertTrue(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1107,7 +1107,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1151,7 +1151,7 @@ class ConfigNodeManagerTest {
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1171,7 +1171,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         GResultOf<ConfigNode> results2 =
-            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(Tags.of("toy", "ball"))));
+            configNodeManager.addNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of("toy", "ball")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1242,7 +1242,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1276,7 +1276,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1310,7 +1310,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1344,7 +1344,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1378,7 +1378,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(resultsOf.hasErrors());
         Assertions.assertTrue(resultsOf.hasResults());
         Assertions.assertNotNull(resultsOf.results());
@@ -1412,7 +1412,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(resultsOf.hasErrors());
         Assertions.assertTrue(resultsOf.hasResults());
         Assertions.assertNotNull(resultsOf.results());
@@ -1446,7 +1446,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> resultsOf = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(resultsOf.hasErrors());
         Assertions.assertTrue(resultsOf.hasResults());
         Assertions.assertNotNull(resultsOf.results());
@@ -1480,7 +1480,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1523,7 +1523,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertTrue(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1572,7 +1572,7 @@ class ConfigNodeManagerTest {
         TestSource source = new TestSource(UUID.randomUUID());
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, source));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, source, Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1594,7 +1594,7 @@ class ConfigNodeManagerTest {
         root2Node.put("db", new MapNode(dbNode2));
         root2Node.put("admin", new ArrayNode(Arrays.asList(arrayNode)));
         ConfigNode root2 = new MapNode(root2Node);
-        results = configNodeManager.reloadNode(new ConfigNodeContainer(root2, new TestSource()));
+        results = configNodeManager.reloadNode(new ConfigNodeContainer(root2, new TestSource(), Tags.of()));
 
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
@@ -1626,7 +1626,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1645,7 +1645,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         ConfigSource s2 = new TestSource();
-        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, s2));
+        GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2, s2, Tags.of()));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1675,7 +1675,7 @@ class ConfigNodeManagerTest {
         rootNode2Reload.put("admin", new ArrayNode(Arrays.asList(arrayNode2reload)));
         ConfigNode root2Reload = new MapNode(rootNode2Reload);
 
-        results = configNodeManager.reloadNode(new ConfigNodeContainer(root2Reload, s2));
+        results = configNodeManager.reloadNode(new ConfigNodeContainer(root2Reload, s2, Tags.of()));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1711,9 +1711,9 @@ class ConfigNodeManagerTest {
 
         // add source 1 to the configNodeManager with tags
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        ConfigSource s1 = new TestSource(Tags.of("toy", "ball"));
+        ConfigSource s1 = new TestSource();
         GResultOf<ConfigNode> results =
-            configNodeManager.addNode(new ConfigNodeContainer(root1, s1));
+            configNodeManager.addNode(new ConfigNodeContainer(root1, s1, Tags.of("toy", "ball")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -1733,9 +1733,9 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(rootNode2);
 
         // add source 2 to the configNodeManager with tags
-        ConfigSource s2 = new TestSource(Tags.of("toy", "ball"));
+        ConfigSource s2 = new TestSource();
         GResultOf<ConfigNode> results2 =
-            configNodeManager.addNode(new ConfigNodeContainer(root2, s2));
+            configNodeManager.addNode(new ConfigNodeContainer(root2, s2, Tags.of("toy", "ball")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1759,7 +1759,7 @@ class ConfigNodeManagerTest {
         // add source 2 to the configNodeManager without tags
         ConfigSource s3 = new TestSource();
         GResultOf<ConfigNode> results3 =
-            configNodeManager.addNode(new ConfigNodeContainer(root3, s3));
+            configNodeManager.addNode(new ConfigNodeContainer(root3, s3, Tags.of()));
         Assertions.assertFalse(results3.hasErrors());
         Assertions.assertTrue(results3.hasResults());
         Assertions.assertNotNull(results3.results());
@@ -1792,7 +1792,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2Reload = new MapNode(rootNode2Reload);
 
         // reload source 2 with tags.
-        results2 = configNodeManager.reloadNode(new ConfigNodeContainer(root2Reload, s2));
+        results2 = configNodeManager.reloadNode(new ConfigNodeContainer(root2Reload, s2, Tags.of("toy", "ball")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());
@@ -1827,7 +1827,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(Arrays.asList(new TestPostProcessor("abc"),
             new TestPostProcessor("def")));
@@ -1879,7 +1879,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(Collections.emptyList());
         Assertions.assertFalse(resultsOf.hasErrors());
@@ -1921,7 +1921,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(Arrays.asList(new TestPostProcessorErrors(),
             new TestPostProcessor("abc")));
@@ -1968,7 +1968,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(Arrays.asList(new TestPostProcessorNoResults(),
             new TestPostProcessor("abc")));
@@ -2000,7 +2000,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(List.of(new TestPostProcessor("abc")));
         Assertions.assertTrue(resultsOf.hasErrors());
@@ -2046,7 +2046,7 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource()));
+        configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(), Tags.of()));
 
         GResultOf<Boolean> resultsOf = configNodeManager.postProcess(List.of(new TestPostProcessor("abc")));
         Assertions.assertTrue(resultsOf.hasErrors());
@@ -2093,7 +2093,8 @@ class ConfigNodeManagerTest {
         ConfigNode root1 = new MapNode(root1Node);
 
         ConfigNodeManager configNodeManager = new ConfigNodeManager();
-        GResultOf<ConfigNode> results = configNodeManager.addNode(new ConfigNodeContainer(root1, new TestSource(Tags.environment("dev"))));
+        GResultOf<ConfigNode> results = configNodeManager.addNode(
+            new ConfigNodeContainer(root1, new TestSource(), Tags.environment("dev")));
         Assertions.assertFalse(results.hasErrors());
         Assertions.assertTrue(results.hasResults());
         Assertions.assertNotNull(results.results());
@@ -2108,7 +2109,7 @@ class ConfigNodeManagerTest {
         ConfigNode root2 = new MapNode(root1Node2);
 
         GResultOf<ConfigNode> results2 = configNodeManager.addNode(new ConfigNodeContainer(root2,
-            new TestSource(Tags.environment("stage"))));
+            new TestSource(), Tags.environment("stage")));
         Assertions.assertFalse(results2.hasErrors());
         Assertions.assertTrue(results2.hasResults());
         Assertions.assertNotNull(results2.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/reload/ManualConfigReloadStrategyTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/reload/ManualConfigReloadStrategyTest.java
@@ -1,10 +1,13 @@
 package org.github.gestalt.config.reload;
 
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.StringConfigSource;
+import org.github.gestalt.config.tag.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 
@@ -16,7 +19,7 @@ class ManualConfigReloadStrategyTest {
         StringConfigSource source = new StringConfigSource("abc=def", "properties");
         ManualConfigReloadStrategy reloadStrategy = new ManualConfigReloadStrategy();
 
-        reloadStrategy.setSource(source);
+        reloadStrategy.setSource(new ConfigSourcePackage(source, List.of(reloadStrategy), Tags.of()));
 
         ConfigReloadListener reloadListener = (it) -> reloadCount.getAndAdd(1);
 
@@ -31,7 +34,7 @@ class ManualConfigReloadStrategyTest {
     public void testManualStrategyWithConstructor() throws GestaltException {
         AtomicInteger reloadCount = new AtomicInteger(0);
         StringConfigSource source = new StringConfigSource("abc=def", "properties");
-        ManualConfigReloadStrategy reloadStrategy = new ManualConfigReloadStrategy(source);
+        ManualConfigReloadStrategy reloadStrategy = new ManualConfigReloadStrategy(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         ConfigReloadListener reloadListener = (it) -> reloadCount.getAndAdd(1);
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/reload/TimedConfigReloadStrategyTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/reload/TimedConfigReloadStrategyTest.java
@@ -3,13 +3,16 @@ package org.github.gestalt.config.reload;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
+import org.github.gestalt.config.tag.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class TimedConfigReloadStrategyTest {
@@ -29,8 +32,56 @@ class TimedConfigReloadStrategyTest {
         configs.put("admin[1]", "Steve");
 
         ConfigSource configSource = new MapConfigSource(configs);
+        var sourcePackage = new ConfigSourcePackage(configSource, List.of(), Tags.of());
         ConfigListener listener = new ConfigListener();
-        TimedConfigReloadStrategy timedConfigReloadStrategy = new TimedConfigReloadStrategy(configSource, Duration.ofMillis(1));
+        TimedConfigReloadStrategy timedConfigReloadStrategy = new TimedConfigReloadStrategy(sourcePackage, Duration.ofMillis(1));
+
+        timedConfigReloadStrategy.registerListener(listener);
+        int count = 0;
+        for (int i = 0; i < 10; i++) {
+            Thread.sleep(10);
+            count = listener.count;
+            if (count >= 1) {
+                break;
+            }
+        }
+
+        Assertions.assertTrue(count >= 1);
+
+        int newCount = 0;
+        for (int i = 0; i < 5; i++) {
+            Thread.sleep(10);
+            newCount = listener.count;
+            if (newCount > count) {
+                break;
+            }
+        }
+
+        Assertions.assertTrue(newCount >= count);
+
+        timedConfigReloadStrategy.removeListener(listener);
+        newCount = listener.count;
+        Thread.sleep(10);
+
+        Assertions.assertEquals(newCount, listener.count);
+
+    }
+
+    @Test
+    public void timedConfigReloadStrategyTest2() throws InterruptedException, GestaltConfigurationException {
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put("db.name", "test");
+        configs.put("db.port", "3306");
+        configs.put("admin[0]", "John");
+        configs.put("admin[1]", "Steve");
+
+        ConfigSource configSource = new MapConfigSource(configs);
+        ConfigListener listener = new ConfigListener();
+        TimedConfigReloadStrategy timedConfigReloadStrategy = new TimedConfigReloadStrategy(Duration.ofMillis(1));
+        var configSourcePackage = new ConfigSourcePackage(configSource, List.of(timedConfigReloadStrategy), Tags.of());
+
+        timedConfigReloadStrategy.setSource(configSourcePackage);
 
         timedConfigReloadStrategy.registerListener(listener);
         int count = 0;
@@ -75,7 +126,8 @@ class TimedConfigReloadStrategyTest {
         ConfigSource configSource = new MapConfigSource(configs);
         ExceptionConfigListener listener = new ExceptionConfigListener();
         TimedConfigReloadStrategy timedConfigReloadStrategy = new TimedConfigReloadStrategy(Duration.ofMillis(1));
-        timedConfigReloadStrategy.setSource(configSource);
+        timedConfigReloadStrategy.setSource(
+            new ConfigSourcePackage(configSource, List.of(timedConfigReloadStrategy), Tags.of()));
 
         ConfigListener listener2 = new ConfigListener();
         timedConfigReloadStrategy.registerListener(listener);
@@ -89,7 +141,7 @@ class TimedConfigReloadStrategyTest {
         public int count = 0;
 
         @Override
-        public void reload(ConfigSource source) {
+        public void reload(ConfigSourcePackage source) {
             count++;
         }
     }
@@ -97,7 +149,7 @@ class TimedConfigReloadStrategyTest {
     private static class ExceptionConfigListener implements ConfigReloadListener {
 
         @Override
-        public void reload(ConfigSource source) throws GestaltException {
+        public void reload(ConfigSourcePackage source) throws GestaltException {
             throw new GestaltException("test exception for time config reload strategy");
         }
     }

--- a/gestalt-core/src/test/resources/defaultPPEnv.properties
+++ b/gestalt-core/src/test/resources/defaultPPEnv.properties
@@ -5,16 +5,16 @@ db.hosts[1].url=jdbc:postgresql://localhost:5432/mydb2
 db.hosts[2].user=credmond
 db.hosts[2].url=jdbc:postgresql://localhost:5432/mydb3
 db.ConnectionTimeout=6000
-db.idleTimeout=${envVar:DB_IDLETIMEOUT:=900}
-db.maxLifetime=${envVar:NO_RESULTS_FOUND:=60000.0}
+db.idleTimeout=${env:DB_IDLETIMEOUT:=900}
+db.maxLifetime=${env:NO_RESULTS_FOUND:=60000.0}
 http.Pool.maxTotal=100
 http.Pool.maxPerRoute=10
 http.Pool.validateAfterInactivity=6000
 http.Pool.keepAliveTimeoutMs=60000
 http.Pool.idleTimeoutSec=25
-subservice.booking.isEnabled=${envVar:SUBSERVICE_BOOKING_ISENABLED}
-subservice.booking.service.host=${envVar:SUBSERVICE_BOOKING_SERVICE_HOST}
-subservice.booking.service.port=${envVar:SUBSERVICE_BOOKING_SERVICE_PORT}
+subservice.booking.isEnabled=${env:SUBSERVICE_BOOKING_ISENABLED}
+subservice.booking.service.host=${env:SUBSERVICE_BOOKING_SERVICE_HOST}
+subservice.booking.service.port=${env:SUBSERVICE_BOOKING_SERVICE_PORT}
 subservice.booking.service.path=booking
 Admin.user=John, Sarah
 Admin.overrideEnabled=false

--- a/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/GestaltConfigTest.java
+++ b/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/GestaltConfigTest.java
@@ -53,7 +53,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.properties").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         // Load the configurations, this will thow exceptions if there are any errors.
@@ -78,7 +77,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
                 .useCacheDecorator(false)
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         // Load the configurations, this will thow exceptions if there are any errors.
@@ -104,7 +102,6 @@ public class GestaltConfigTest {
                     .build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
                 .addSource(StringConfigSourceBuilder.builder().setConfig("db.idleTimeout=123").setFormat("properties").build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -166,7 +163,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
                 .addSource(EnvironmentConfigSourceBuilder.builder().build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -192,7 +188,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.json").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.json").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -212,7 +207,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.yml").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.yml").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -232,7 +226,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.json").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.yml").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -252,7 +245,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.conf").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.yml").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -272,7 +264,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.conf").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.toml").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -302,7 +293,6 @@ public class GestaltConfigTest {
                 .addSource(source)
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -349,7 +339,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("/default.properties").build())
                 .addSource(GCSConfigSourceBuilder.builder().setBucketName("gestalt-test").setObjectName("dev.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         // Load the configurations, this will thow exceptions if there are any errors.
@@ -413,7 +402,6 @@ public class GestaltConfigTest {
                     .setKeyName("dev.properties")
                     .build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .addModuleConfig(AWSBuilder.builder().setRegion("us-east-1").build())
                 .build();
 
@@ -453,7 +441,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("/defaultPPVault.properties").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("/integration.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .addModuleConfig(vaultModuleConfig)
                 .build();
 
@@ -690,7 +677,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("integration.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
                 .addDefaultPostProcessors()
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -730,7 +716,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("integration.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
                 .addPostProcessor(new TransformerPostProcessor(List.of(new SystemPropertiesTransformer(), new RandomTransformer())))
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();
@@ -760,7 +745,6 @@ public class GestaltConfigTest {
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("defaultPPNode.properties").build())
                 .addSource(ClassPathConfigSourceBuilder.builder().setResource("integration.properties").build())
                 .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-                .setTreatNullValuesInClassAsErrors(false)
                 .build();
 
         gestalt.loadConfigs();

--- a/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/MainOverride.java
+++ b/gestalt-examples/gestalt-sample-module/src/main/java/org/github/gestalt/config/integration/MainOverride.java
@@ -22,7 +22,6 @@ public class MainOverride {
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.properties").build())
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
             .addSource(SystemPropertiesConfigSourceBuilder.builder().build())
-            .setTreatNullValuesInClassAsErrors(false)
             .build();
 
         // Load the configurations, this will throw exceptions if there are any errors.

--- a/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/GestaltKotlinTest.kt
+++ b/gestalt-examples/gestalt-sample-module/src/main/kotlin/org/github/gestalt/config/integration/GestaltKotlinTest.kt
@@ -26,7 +26,6 @@ class GestaltKotlinTest {
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.properties").build())
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
             .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-            .setTreatNullValuesInClassAsErrors(false)
             .build()
         gestalt.loadConfigs()
         testValidation(gestalt)
@@ -44,7 +43,6 @@ class GestaltKotlinTest {
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
             .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
             .addSource(EnvironmentConfigSourceBuilder.builder().build())
-            .setTreatNullValuesInClassAsErrors(false)
             .build()
         gestalt.loadConfigs()
         testValidation(gestalt)
@@ -69,7 +67,6 @@ class GestaltKotlinTest {
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("default.properties").build())
             .addSource(ClassPathConfigSourceBuilder.builder().setResource("dev.properties").build())
             .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
-            .setTreatNullValuesInClassAsErrors(false)
             .build()
         gestalt.loadConfigs()
         val pool: HttpPool = gestalt.getConfig("http.pool", KTypeCapture.of<HttpPool>(typeOf<HttpPool>())) as HttpPool

--- a/gestalt-examples/gestalt-sample/src/test/kotlin/org/github/gestalt/config/kotlin/integration/GestaltKotlinSample.kt
+++ b/gestalt-examples/gestalt-sample/src/test/kotlin/org/github/gestalt/config/kotlin/integration/GestaltKotlinSample.kt
@@ -1,6 +1,5 @@
 package org.github.gestalt.config.kotlin.integration
 
-import io.mockk.core.ValueClassSupport.boxedValue
 import org.github.gestalt.config.Gestalt
 import org.github.gestalt.config.annotations.Config
 import org.github.gestalt.config.builder.GestaltBuilder
@@ -10,13 +9,9 @@ import org.github.gestalt.config.kotlin.kodein.gestalt
 import org.github.gestalt.config.kotlin.koin.gestalt
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.reflect.TypeCapture
-import org.github.gestalt.config.source.ClassPathConfigSource
 import org.github.gestalt.config.source.ClassPathConfigSourceBuilder
-import org.github.gestalt.config.source.EnvironmentConfigSource
 import org.github.gestalt.config.source.EnvironmentConfigSourceBuilder
-import org.github.gestalt.config.source.FileConfigSource
 import org.github.gestalt.config.source.FileConfigSourceBuilder
-import org.github.gestalt.config.source.MapConfigSource
 import org.github.gestalt.config.source.MapConfigSourceBuilder
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll

--- a/gestalt-examples/gestalt-sample/src/test/resources/defaultPPEnv.properties
+++ b/gestalt-examples/gestalt-sample/src/test/resources/defaultPPEnv.properties
@@ -5,8 +5,8 @@ db.hosts[1].url=jdbc:postgresql://localhost:5432/mydb2
 db.hosts[2].user=credmond
 db.hosts[2].url=jdbc:postgresql://localhost:5432/mydb3
 db.ConnectionTimeout=6000
-db.idleTimeout=${envVar:DB_IDLETIMEOUT:=900}
-db.maxLifetime=${envVar:NO_RESULTS_FOUND:=60000.0}
+db.idleTimeout=${env:DB_IDLETIMEOUT:=900}
+db.maxLifetime=${env:NO_RESULTS_FOUND:=60000.0}
 http.Pool.maxTotal=100
 http.Pool.maxPerRoute=10
 http.Pool.validateAfterInactivity=6000

--- a/gestalt-git/src/main/java/org/github/gestalt/config/git/GitConfigSource.java
+++ b/gestalt-git/src/main/java/org/github/gestalt/config/git/GitConfigSource.java
@@ -9,6 +9,7 @@ import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.SshTransport;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.Pair;
 
@@ -65,7 +66,9 @@ public final class GitConfigSource implements ConfigSource {
      *     The easiest way is to use the apache mina-sshd SshdSessionFactoryBuilder.
      * @param tags tags associated with the source
      * @throws GestaltException if there is a badly configured git repo
+     * @deprecated Tags should be added via the builder. Storage of the tags have been moved to {@link ConfigSourcePackage#getTags()}.
      */
+    @Deprecated(since = "0.26.0", forRemoval = true)
     public GitConfigSource(String repoURI, Path localRepoDirectory, String configFilePath, String branch, CredentialsProvider credentials,
                            SshSessionFactory sshSessionFactory, Tags tags) throws GestaltException {
         if (repoURI == null) {

--- a/gestalt-git/src/main/java/org/github/gestalt/config/git/GitConfigSourceBuilder.java
+++ b/gestalt-git/src/main/java/org/github/gestalt/config/git/GitConfigSourceBuilder.java
@@ -114,6 +114,6 @@ public final class GitConfigSourceBuilder extends SourceBuilder<GitConfigSourceB
      */
     @Override
     public ConfigSourcePackage build() throws GestaltException {
-        return buildPackage(new GitConfigSource(repoURI, localRepoDirectory, configFilePath, branch, credentials, sshSessionFactory, tags));
+        return buildPackage(new GitConfigSource(repoURI, localRepoDirectory, configFilePath, branch, credentials, sshSessionFactory));
     }
 }

--- a/gestalt-git/src/test/java/org/github/gestalt/config/git/GitConfigSourceTest.java
+++ b/gestalt-git/src/test/java/org/github/gestalt/config/git/GitConfigSourceTest.java
@@ -307,6 +307,6 @@ class GitConfigSourceTest {
             .setTags(Tags.of("toy", "ball"));
         ConfigSourcePackage source = builder.build();
 
-        Assertions.assertEquals(Tags.of("toy", "ball"), source.getConfigSource().getTags());
+        Assertions.assertEquals(Tags.of("toy", "ball"), source.getTags());
     }
 }

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
@@ -9,7 +9,7 @@ import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
 
@@ -61,13 +61,14 @@ public final class HoconLoader implements ConfigLoader {
      * Then convert them to a list of pairs with the path and value.
      * Pass these into the ConfigCompiler to build a config node tree.
      *
-     * @param source source we want to load with this config loader.
+     * @param sourcePackage source we want to load with this config loader.
      * @return GResultOf config node or errors.
      * @throws GestaltException any errors.
      */
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
 
+        var source = sourcePackage.getConfigSource();
         if (source.hasStream()) {
             try (InputStream is = source.loadStream()) {
                 Config config = ConfigFactory.parseReader(
@@ -78,7 +79,7 @@ public final class HoconLoader implements ConfigLoader {
                 }
 
                 GResultOf<ConfigNode> node = buildConfigTree("", config.root());
-                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source)));
+                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
             } catch (ConfigException | NullPointerException | IOException e) {
                 throw new GestaltException("Exception loading source: " + source.name(), e);
             }

--- a/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconLoaderTest.java
+++ b/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconLoaderTest.java
@@ -2,12 +2,12 @@ package org.github.gestalt.config.hocon;
 
 import com.typesafe.config.ConfigParseOptions;
 import com.typesafe.config.ConfigSyntax;
-import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.node.ConfigNode;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
-import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.tag.Tags;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -81,7 +81,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -116,7 +116,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader(ConfigParseOptions.defaults().setSyntax(ConfigSyntax.JSON));
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
 
@@ -146,7 +146,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -163,7 +163,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -183,7 +183,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
 
@@ -203,7 +203,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
 
@@ -225,7 +225,7 @@ class HoconLoaderTest {
         HoconLoader hoconLoader = new HoconLoader();
 
         try {
-            hoconLoader.loadSource(source);
+            hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Exception loading source: String format: conf", e.getMessage());
@@ -241,7 +241,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -258,7 +258,7 @@ class HoconLoaderTest {
 
         HoconLoader hoconLoader = new HoconLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = hoconLoader.loadSource(source);
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
 
@@ -275,7 +275,7 @@ class HoconLoaderTest {
         HoconLoader hoconLoader = new HoconLoader();
 
         try {
-            hoconLoader.loadSource(source);
+            hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("HOCON Config source: mapConfig does not have a stream to load.", e.getMessage());

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
@@ -10,7 +10,7 @@ import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
 
@@ -58,13 +58,14 @@ public final class JsonLoader implements ConfigLoader {
      * Then convert them to a list of pairs with the path and value.
      * Pass these into the ConfigCompiler to build a config node tree.
      *
-     * @param source source we want to load with this config loader.
+     * @param sourcePackage source we want to load with this config loader.
      * @return GResultOf config node or errors.
      * @throws GestaltException any errors.
      */
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
 
+        var source = sourcePackage.getConfigSource();
         if (source.hasStream()) {
             try (InputStream is = source.loadStream()) {
                 JsonNode jsonNode = objectMapper.readTree(is);
@@ -74,7 +75,7 @@ public final class JsonLoader implements ConfigLoader {
 
                 GResultOf<ConfigNode> node = buildConfigTree("", jsonNode);
 
-                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source)));
+                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
             } catch (IOException | NullPointerException e) {
                 throw new GestaltException("Exception loading source: " + source.name(), e);
             }

--- a/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
+++ b/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.node.ConfigNode;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
 import org.github.gestalt.config.tag.Tags;
@@ -45,7 +46,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -80,7 +81,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -116,7 +117,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -151,7 +152,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader(new ObjectMapper());
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
 
@@ -180,7 +181,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -201,7 +202,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -223,7 +224,7 @@ class JsonLoaderTest {
 
         JsonLoader jsonLoader = new JsonLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -246,7 +247,7 @@ class JsonLoaderTest {
         JsonLoader jsonLoader = new JsonLoader();
 
         try {
-            jsonLoader.loadSource(source);
+            jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Exception loading source: String format: json", e.getMessage());
@@ -262,7 +263,7 @@ class JsonLoaderTest {
         JsonLoader jsonLoader = new JsonLoader();
 
         try {
-            jsonLoader.loadSource(source);
+            jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Config source: mapConfig does not have a stream to load.", e.getMessage());

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
@@ -11,7 +11,7 @@ import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
 
@@ -60,13 +60,14 @@ public final class TomlLoader implements ConfigLoader {
      * Then convert them to a list of pairs with the path and value.
      * Pass these into the ConfigCompiler to build a config node tree.
      *
-     * @param source source we want to load with this config loader.
+     * @param sourcePackage source we want to load with this config loader.
      * @return GResultOf config node or errors.
      * @throws GestaltException any errors.
      */
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
 
+        var source = sourcePackage.getConfigSource();
         if (source.hasStream()) {
             try (InputStream is = source.loadStream()) {
                 JsonNode jsonNode = objectMapper.readTree(is);
@@ -76,7 +77,7 @@ public final class TomlLoader implements ConfigLoader {
 
                 GResultOf<ConfigNode> node = buildConfigTree("", jsonNode);
 
-                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source)));
+                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
             } catch (IOException | NullPointerException e) {
                 throw new GestaltException("Exception loading source: " + source.name(), e);
             }

--- a/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
+++ b/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.dataformat.toml.TomlFactory;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.node.ConfigNode;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.GResultOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -50,7 +52,7 @@ class TomlLoaderTest {
 
         TomlLoader tomlLoader = new TomlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -90,7 +92,7 @@ class TomlLoaderTest {
 
         TomlLoader tomlLoader = new TomlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -130,7 +132,7 @@ class TomlLoaderTest {
 
         TomlLoader tomlLoader = new TomlLoader(new ObjectMapper(new TomlFactory()));
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -159,7 +161,7 @@ class TomlLoaderTest {
         TomlLoader tomlLoader = new TomlLoader();
 
         try {
-            tomlLoader.loadSource(source);
+            tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here, should throw exception");
         } catch (GestaltException e) {
             Assertions.assertEquals("Exception loading source: String format: toml", e.getMessage());
@@ -173,7 +175,7 @@ class TomlLoaderTest {
 
         TomlLoader tomlLoader = new TomlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -191,7 +193,7 @@ class TomlLoaderTest {
         TomlLoader tomlLoader = new TomlLoader();
 
         try {
-            tomlLoader.loadSource(source);
+            tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Exception loading source: String format: toml", e.getMessage());
@@ -207,7 +209,7 @@ class TomlLoaderTest {
         TomlLoader tomlLoader = new TomlLoader();
 
         try {
-            tomlLoader.loadSource(source);
+            tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Config source: mapConfig does not have a stream to load.", e.getMessage());

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
@@ -11,7 +11,7 @@ import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
-import org.github.gestalt.config.source.ConfigSource;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
 
@@ -62,13 +62,14 @@ public final class YamlLoader implements ConfigLoader {
      * Then convert them to a list of pairs with the path and value.
      * Pass these into the ConfigCompiler to build a config node tree.
      *
-     * @param source source we want to load with this config loader.
+     * @param sourcePackage source we want to load with this config loader.
      * @return GResultOf config node or errors.
      * @throws GestaltException any errors.
      */
     @Override
-    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSource source) throws GestaltException {
+    public GResultOf<List<ConfigNodeContainer>> loadSource(ConfigSourcePackage sourcePackage) throws GestaltException {
 
+        var source = sourcePackage.getConfigSource();
         if (source.hasStream()) {
             try (InputStream is = source.loadStream()) {
                 JsonNode jsonNode = objectMapper.readTree(is);
@@ -77,11 +78,11 @@ public final class YamlLoader implements ConfigLoader {
                 }
 
                 if (jsonNode.getNodeType() == MISSING) {
-                    return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source)));
+                    return GResultOf.result(List.of(new ConfigNodeContainer(new MapNode(Map.of()), source, sourcePackage.getTags())));
                 }
 
                 GResultOf<ConfigNode> node = buildConfigTree("", jsonNode);
-                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source)));
+                return node.mapWithError(result -> List.of(new ConfigNodeContainer(result, source, sourcePackage.getTags())));
             } catch (IOException | NullPointerException e) {
                 throw new GestaltException("Exception loading source: " + source.name(), e);
             }

--- a/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
+++ b/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.node.ConfigNode;
+import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
+import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.GResultOf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,7 +48,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -81,7 +83,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -116,7 +118,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader(new ObjectMapper(new YAMLFactory()));
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());
@@ -144,7 +146,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertTrue(resultContainer.hasErrors());
         Assertions.assertEquals("Unable to find node matching path: age", resultContainer.getErrors().get(0).description());
@@ -166,7 +168,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertTrue(resultContainer.hasErrors());
         Assertions.assertEquals("Unable to find node matching path: cars", resultContainer.getErrors().get(0).description());
@@ -187,7 +189,7 @@ class YamlLoaderTest {
         YamlLoader yamlLoader = new YamlLoader();
 
         try {
-            yamlLoader.loadSource(source);
+            yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Exception loading source: String format: yml", e.getMessage());
@@ -203,7 +205,7 @@ class YamlLoaderTest {
         YamlLoader yamlLoader = new YamlLoader();
 
         try {
-            yamlLoader.loadSource(source);
+            yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
             Assertions.fail("should not reach here");
         } catch (Exception e) {
             Assertions.assertEquals("Config source: mapConfig does not have a stream to load.", e.getMessage());
@@ -217,7 +219,7 @@ class YamlLoaderTest {
 
         YamlLoader yamlLoader = new YamlLoader();
 
-        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(source);
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
         Assertions.assertTrue(resultContainer.hasResults());

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ checkStyle = "10.10.0"
 jmh = "1.37"
 gradleJmh = "0.7.2"
 # @pin gestalt for integration tests.
-gestalt = "0.25.1"
+gestalt = "0.25.3"
 # Gradle utility
 gradleVersions = "0.51.0"
 gitVersions = "3.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 java = "11"
 javaLatest = "21"
 # @pin
-kotlin = "1.9.22"
+kotlin = "1.9.23"
 # @pin
 kotlinDokka = "1.9.20"
 # Kotlin DI
@@ -20,7 +20,7 @@ weldCore = "4.0.3.Final"
 jackson = "2.17.0"
 hocon = "1.4.3"
 # Cloud
-awsBom = "2.25.15"
+awsBom = "2.25.19"
 gcpLibraries = "26.34.0"
 # vault
 vault = "6.2.0"
@@ -39,7 +39,7 @@ testcontainers = "1.19.7"
 # static code analysis
 errorprone = "2.26.1"
 gradleErrorProne = "3.1.0"
-detekt = "1.23.5"
+detekt = "1.23.6"
 checkStyle = "10.10.0"
 # benchmarking
 jmh = "1.37"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 


### PR DESCRIPTION
feat: add tags to the ConfigSourcePackage and ConfigNodeContainer. Th…en deprecate the tags in ConfigSource. Keep backwards compatibility https://github.com/gestalt-config/gestalt/issues/169

Add warning logs to depricated EnvironmentVariablesTransformerOld or  "envVar" string substitution. Reload strategies use ConfigSourcePackage  instead of ConfigSource.