### PR TITLE
Propagate lexer from Gestalt Config to various locations

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
@@ -116,6 +116,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         return decoderContext;
     }
 
+
     /**
      * register a core event listener.
      *

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
@@ -595,10 +595,15 @@ public class GestaltBuilder {
 
 
     /**
+     * ***USE WITH CAUTION.***
      * Set the sentence lexer that will be used throughout Gestalt.
      * It is used in several locations, to convert the path requested to tokens, so we can navigate the config tree using the tokens.
      * It is used to normalize sentences when parsing configs. (except Environment Variables)
      * It is also used in the path mappers to try different ways to navigate the config tree during decoding.
+     *
+     * <p>If you set a new lexer that is for example case-sensitive, when you decode an object
+     * public record Person(String name, Integer id) if in the properties it is admin.Name = sarah
+     * it will not be able to decode as the name field is lower case and the property is upper case.
      *
      * @param sentenceLexer for the DecoderRegistry
      * @return GestaltBuilder builder

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
-import static org.github.gestalt.config.decoder.ProxyDecoderMode.CACHE;
 
 /**
  * Builder to setup and create the Gestalt config class.
@@ -93,6 +92,10 @@ public class GestaltBuilder {
     private Boolean treatMissingArrayIndexAsError = null;
     private Boolean treatMissingValuesAsErrors = null;
     private Boolean treatMissingDiscretionaryValuesAsErrors = null;
+    // If we should enable metrics
+    private Boolean metricsEnabled = null;
+    // If we should enable Validation
+    private Boolean validationEnabled = null;
 
     private Level logLevelForMissingValuesWhenDefaultOrOptional = null;
 
@@ -114,17 +117,13 @@ public class GestaltBuilder {
     private String substitutionRegex = null;
 
     // Defines how the proxy decoder works. See the enum for details.
-    private ProxyDecoderMode proxyDecoderMode = CACHE;
+    private ProxyDecoderMode proxyDecoderMode = null;
 
 
     // Default set of tags to apply to all calls to get a configuration where tags are not provided.
     private Tags defaultTags = Tags.of();
 
-    // If we should enable metrics
-    private Boolean metricsEnabled = null;
 
-    // If we should enable Validation
-    private Boolean validationEnabled = null;
 
     /**
      * Adds all default decoders to the builder. Uses the ServiceLoader to find all registered Decoders and adds them
@@ -140,10 +139,6 @@ public class GestaltBuilder {
         return this;
     }
 
-    private void configureDecoders() {
-        decoders.forEach(it -> it.applyConfig(gestaltConfig));
-    }
-
     /**
      * Add default config loaders to the builder. Uses the ServiceLoader to find all registered Config Loaders and adds them
      *
@@ -152,16 +147,9 @@ public class GestaltBuilder {
     public GestaltBuilder addDefaultConfigLoaders() {
         List<ConfigLoader> configLoaderSet = new ArrayList<>();
         ServiceLoader<ConfigLoader> loader = ServiceLoader.load(ConfigLoader.class);
-        loader.forEach(it -> {
-            it.applyConfig(gestaltConfig);
-            configLoaderSet.add(it);
-        });
+        loader.forEach(configLoaderSet::add);
         configLoaders.addAll(configLoaderSet);
         return this;
-    }
-
-    private void configureConfigLoaders() {
-        configLoaders.forEach(it -> it.applyConfig(gestaltConfig));
     }
 
     /**
@@ -172,11 +160,7 @@ public class GestaltBuilder {
     public GestaltBuilder addDefaultPostProcessors() {
         List<PostProcessor> postProcessorsSet = new ArrayList<>();
         ServiceLoader<PostProcessor> loader = ServiceLoader.load(PostProcessor.class);
-        loader.forEach(it -> {
-            PostProcessorConfig config = new PostProcessorConfig(gestaltConfig, configNodeService, sentenceLexer, secretConcealer);
-            it.applyConfig(config);
-            postProcessorsSet.add(it);
-        });
+        loader.forEach(postProcessorsSet::add);
         postProcessors.addAll(postProcessorsSet);
         return this;
     }
@@ -209,13 +193,6 @@ public class GestaltBuilder {
         return this;
     }
 
-    private void configurePostProcessors() {
-        postProcessors.forEach(it -> {
-            PostProcessorConfig config = new PostProcessorConfig(gestaltConfig, configNodeService, sentenceLexer, secretConcealer);
-            it.applyConfig(config);
-        });
-    }
-
     /**
      * Add default post processors to the builder. Uses the ServiceLoader to find all registered post processors and adds them
      *
@@ -227,18 +204,6 @@ public class GestaltBuilder {
         loader.forEach(pathMappersSet::add);
         pathMappers.addAll(pathMappersSet);
         return this;
-    }
-
-    private void configurePathMappers() {
-        pathMappers.forEach(it -> it.applyConfig(gestaltConfig));
-    }
-
-    private void configureMetricsRecorders() {
-        metricsRecorders.forEach(it -> it.applyConfig(gestaltConfig));
-    }
-
-    private void configureValidators() {
-        configValidators.forEach(it -> it.applyConfig(gestaltConfig));
     }
 
     /**
@@ -630,7 +595,10 @@ public class GestaltBuilder {
 
 
     /**
-     * Set the sentence lexer that will be passed through to the DecoderRegistry.
+     * Set the sentence lexer that will be used throughout Gestalt.
+     * It is used in several locations, to convert the path requested to tokens, so we can navigate the config tree using the tokens.
+     * It is used to normalize sentences when parsing configs. (except Environment Variables)
+     * It is also used in the path mappers to try different ways to navigate the config tree during decoding.
      *
      * @param sentenceLexer for the DecoderRegistry
      * @return GestaltBuilder builder
@@ -696,7 +664,6 @@ public class GestaltBuilder {
         validationManager.addValidators(configValidators);
         return this;
     }
-
 
 
     /**
@@ -1114,89 +1081,12 @@ public class GestaltBuilder {
         gestaltConfig = rebuildConfig();
         gestaltConfig.registerModuleConfig(modules);
 
-
-        // setup the decoders, if there are none, add the default ones.
-        if (decoders.isEmpty()) {
-            logger.log(TRACE, "No decoders provided, using defaults");
-            addDefaultDecoders();
-        }
-        decoders = decoders.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-        // setup the default path mappers, if there are none, add the default ones.
-        if (pathMappers.isEmpty()) {
-            logger.log(TRACE, "No path mapper provided, using defaults");
-            addDefaultPathMappers();
-        }
-        pathMappers = pathMappers.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-        // setup the default metricsRecorders, if there are none add the default ones.
-        if (metricsRecorders.isEmpty()) {
-            logger.log(TRACE, "No metric recorders provided, using defaults");
-            addDefaultMetricsRecorder();
-        }
-        metricsRecorders = metricsRecorders.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-        // setup the default validators, if there are none add the default ones.
-        if (configValidators.isEmpty()) {
-            logger.log(TRACE, "No validators recorders provided, using defaults");
-            addDefaultValidators();
-        }
-        configValidators = configValidators.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-
-        // if the metricsManager does not exist, create it.
-        // Otherwise, get all the recorders from the metricsManager, combine them with the ones in the builder,
-        if (metricsManager == null) {
-            metricsManager = new MetricsManager(metricsRecorders);
-        } else {
-            metricsManager.addMetricsRecorders(metricsRecorders);
-        }
-
-        // if the metricsManager does not exist, create it.
-        // Otherwise, get all the recorders from the metricsManager, combine them with the ones in the builder,
-        if (validationManager == null) {
-            validationManager = new ValidationManager(configValidators);
-        } else {
-            validationManager.addValidators(configValidators);
-        }
-
-        // if the decoderService does not exist, create it.
-        // Otherwise get all the decoders from the decoderService, combine them with the ones in the builder,
-        // and update the decoderService
-        if (decoderService == null) {
-            decoderService = new DecoderRegistry(decoders, configNodeService, sentenceLexer, pathMappers);
-        } else {
-            decoders.addAll(decoderService.getDecoders());
-            List<Decoder<?>> dedupedDecoders = dedupeDecoders();
-            decoderService.setDecoders(dedupedDecoders);
-        }
-
-        // Setup the config loaders.
-        if (configLoaders.isEmpty()) {
-            logger.log(TRACE, "No decoders provided, using defaults");
-            addDefaultConfigLoaders();
-        }
-        configLoaders = configLoaders.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-        if (postProcessors.isEmpty()) {
-            logger.log(TRACE, "No post processors provided, using defaults");
-            addDefaultPostProcessors();
-        }
-        postProcessors = postProcessors.stream().filter(Objects::nonNull).collect(Collectors.toList());
-
-        // get all the config loaders from the configLoaderRegistry, combine them with the ones in the builder,
-        // and update the configLoaderRegistry
-        configLoaders.addAll(configLoaderService.getConfigLoaders());
-        List<ConfigLoader> dedupedConfigs = dedupeConfigLoaders();
-        configLoaderService.setLoaders(dedupedConfigs);
-
-        // configure all the various services
+        configurePathMappers();
         configureDecoders();
+        configureMetrics();
+        configureValidators();
         configureConfigLoaders();
         configurePostProcessors();
-        configurePathMappers();
-        configureMetricsRecorders();
-        configureValidators();
 
         // create a new GestaltCoreReloadStrategy to listen for Gestalt Core Reloads.
         CoreReloadListenersContainer coreReloadListenersContainer = new CoreReloadListenersContainer();
@@ -1223,6 +1113,101 @@ public class GestaltBuilder {
             return gestaltCache;
         } else {
             return gestaltCore;
+        }
+    }
+
+    private void configurePostProcessors() {
+        if (postProcessors.isEmpty()) {
+            logger.log(TRACE, "No post processors provided, using defaults");
+            addDefaultPostProcessors();
+        }
+        postProcessors = postProcessors.stream().filter(Objects::nonNull).collect(Collectors.toList());
+
+        PostProcessorConfig config = new PostProcessorConfig(gestaltConfig, configNodeService, sentenceLexer, secretConcealer);
+        postProcessors.forEach(it -> it.applyConfig(config));
+    }
+
+    private void configureConfigLoaders() {
+        // Setup the config loaders.
+        if (configLoaders.isEmpty()) {
+            logger.log(TRACE, "No decoders provided, using defaults");
+            addDefaultConfigLoaders();
+        }
+        // get all the config loaders from the configLoaderRegistry, combine them with the ones in the builder,
+        // and update the configLoaderRegistry
+        configLoaders.addAll(configLoaderService.getConfigLoaders());
+        List<ConfigLoader> dedupedConfigs = dedupeConfigLoaders();
+
+        configLoaders = configLoaders.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        configLoaders.forEach(it -> it.applyConfig(gestaltConfig));
+
+        configLoaderService.setLoaders(dedupedConfigs);
+    }
+
+    private void configureValidators() {
+        // setup the default validators, if there are none add the default ones.
+        if (configValidators.isEmpty()) {
+            logger.log(TRACE, "No validators recorders provided, using defaults");
+            addDefaultValidators();
+        }
+        configValidators = configValidators.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        configValidators.forEach(it -> it.applyConfig(gestaltConfig));
+
+        // if the metricsManager does not exist, create it.
+        // Otherwise, get all the recorders from the metricsManager, combine them with the ones in the builder,
+        if (validationManager == null) {
+            validationManager = new ValidationManager(configValidators);
+        } else {
+            validationManager.addValidators(configValidators);
+        }
+    }
+
+    private void configureMetrics() {
+        // setup the default metricsRecorders, if there are none add the default ones.
+        if (metricsRecorders.isEmpty()) {
+            logger.log(TRACE, "No metric recorders provided, using defaults");
+            addDefaultMetricsRecorder();
+        }
+        metricsRecorders = metricsRecorders.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        metricsRecorders.forEach(it -> it.applyConfig(gestaltConfig));
+
+        // if the metricsManager does not exist, create it.
+        // Otherwise, get all the recorders from the metricsManager, combine them with the ones in the builder,
+        if (metricsManager == null) {
+            metricsManager = new MetricsManager(metricsRecorders);
+        } else {
+            metricsManager.addMetricsRecorders(metricsRecorders);
+        }
+    }
+
+    private void configurePathMappers() {
+        // setup the default path mappers, if there are none, add the default ones.
+        if (pathMappers.isEmpty()) {
+            logger.log(TRACE, "No path mapper provided, using defaults");
+            addDefaultPathMappers();
+        }
+        pathMappers = pathMappers.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        pathMappers.forEach(it -> it.applyConfig(gestaltConfig));
+    }
+
+    private void configureDecoders() throws GestaltConfigurationException {
+        // setup the decoders, if there are none, add the default ones.
+        if (decoders.isEmpty()) {
+            logger.log(TRACE, "No decoders provided, using defaults");
+            addDefaultDecoders();
+        }
+        decoders = decoders.stream().filter(Objects::nonNull).collect(Collectors.toList());
+        decoders.forEach(it -> it.applyConfig(gestaltConfig));
+
+        // if the decoderService does not exist, create it.
+        // Otherwise get all the decoders from the decoderService, combine them with the ones in the builder,
+        // and update the decoderService
+        if (decoderService == null) {
+            decoderService = new DecoderRegistry(decoders, configNodeService, sentenceLexer, pathMappers);
+        } else {
+            decoders.addAll(decoderService.getDecoders());
+            List<Decoder<?>> dedupedDecoders = dedupeDecoders();
+            decoderService.setDecoders(dedupedDecoders);
         }
     }
 
@@ -1274,6 +1259,9 @@ public class GestaltBuilder {
 
         newConfig.setValidationEnabled(Objects.requireNonNullElseGet(validationEnabled,
             () -> gestaltConfig.isValidationEnabled()));
+
+        newConfig.setSentenceLexer(Objects.requireNonNullElseGet(sentenceLexer,
+            () -> gestaltConfig.getSentenceLexer()));
 
         return newConfig;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/GestaltConfig.java
@@ -1,6 +1,8 @@
 package org.github.gestalt.config.entity;
 
 import org.github.gestalt.config.decoder.ProxyDecoderMode;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.post.process.transform.TransformerPostProcessor;
 
 import java.time.format.DateTimeFormatter;
@@ -44,12 +46,13 @@ public class GestaltConfig {
     // Must have a named capture group transform, key, and default, where the key is required and the transform and default are optional.
     private String substitutionRegex = TransformerPostProcessor.DEFAULT_SUBSTITUTION_REGEX;
 
-
     // if metrics should be enabled
     private boolean metricsEnabled = false;
 
     // if validation should be enabled.
     private boolean validationEnabled = false;
+    // The sentence lexer used for gestalt.
+    private SentenceLexer sentenceLexer = new PathLexer();
 
     /**
      * Treat all warnings as errors.
@@ -352,6 +355,26 @@ public class GestaltConfig {
      */
     public void setValidationEnabled(boolean validationEnabled) {
         this.validationEnabled = validationEnabled;
+    }
+
+    /**
+     * Get the sentence lexer that will be passed through to the DecoderRegistry.
+     * it is used to convert the path requested to tokens, so we can navigate the config tree using the tokens.
+     *
+     * @return SentenceLexer the lexer
+     */
+    public SentenceLexer getSentenceLexer() {
+        return sentenceLexer;
+    }
+
+    /**
+     * Set the sentence lexer that will be passed through to the DecoderRegistry.
+     * it is used to convert the path requested to tokens, so we can navigate the config tree using the tokens.
+     *
+     * @param sentenceLexer for the DecoderRegistry
+     */
+    public void setSentenceLexer(SentenceLexer sentenceLexer) {
+        this.sentenceLexer = sentenceLexer;
     }
 
     /**

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/LowerCaseSentenceNormalizer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/LowerCaseSentenceNormalizer.java
@@ -1,0 +1,10 @@
+package org.github.gestalt.config.lexer;
+
+import java.util.Locale;
+
+public class LowerCaseSentenceNormalizer implements SentenceNormalizer {
+    @Override
+    public String normalizeSentence(String sentence) {
+        return sentence.toLowerCase(Locale.getDefault());
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
@@ -31,6 +31,7 @@ public final class PathLexer extends SentenceLexer {
     private final Pattern pathPattern;
     private final String delimiter;
     private final String delimiterRegex;
+    private final SentenceNormalizer sentenceNormalizer;
 
     /**
      * Build a path lexer to tokenize a path.
@@ -39,6 +40,7 @@ public final class PathLexer extends SentenceLexer {
         this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
         this.delimiter = DELIMITER_DEFAULT;
         this.delimiterRegex = Pattern.quote(DELIMITER_DEFAULT);
+        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
     }
 
     /**
@@ -50,6 +52,7 @@ public final class PathLexer extends SentenceLexer {
         this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
+        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
     }
 
     /**
@@ -65,6 +68,24 @@ public final class PathLexer extends SentenceLexer {
         this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
+        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
+    }
+
+    /**
+     * construct a Path lexer, remember that the delimiter is a regex, so if you want to use . you need to escape it. "."
+     *
+     * @param delimiter        the character to split the sentence
+     * @param pathPatternRegex a regex with capture groups to decide what kind of token this is. The regex should have a capture group
+     *                         name = name of the element
+     *                         array = if this element is an array
+     *                         index = the index for the array
+     * @param sentenceNormalizer defines how to normalize a sentence.
+     */
+    public PathLexer(String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
+        this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
+        this.delimiter = delimiter;
+        this.delimiterRegex = Pattern.quote(delimiter);
+        this.sentenceNormalizer = sentenceNormalizer;
     }
 
     @Override
@@ -120,5 +141,10 @@ public final class PathLexer extends SentenceLexer {
         }
 
         return results;
+    }
+
+    @Override
+    public String normalizeSentence(String sentence) {
+        return sentenceNormalizer.normalizeSentence(sentence);
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
@@ -5,7 +5,6 @@ import org.github.gestalt.config.token.Token;
 import org.github.gestalt.config.utils.GResultOf;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -46,9 +45,7 @@ public abstract class SentenceLexer {
      * @param sentence input sentence to normalize
      * @return a normalized sentence.
      */
-    public String normalizeSentence(String sentence) {
-        return sentence.toLowerCase(Locale.getDefault());
-    }
+    public abstract String normalizeSentence(String sentence);
 
     /**
      * Scan a string a provide a list of tokens.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceNormalizer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceNormalizer.java
@@ -1,0 +1,11 @@
+package org.github.gestalt.config.lexer;
+
+public interface SentenceNormalizer {
+    /**
+     * Takes a sentence and normalize it so we can match tokens from all various systems.
+     *
+     * @param sentence input sentence to normalize
+     * @return a normalized sentence.
+     */
+    String normalizeSentence(String sentence);
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoader.java
@@ -61,13 +61,14 @@ public final class EnvironmentVarsLoader implements ConfigLoader {
     public void applyConfig(GestaltConfig config) {
         // for the Environment Variables ConfigLoader we do not use the default gestalt config lexer,
         // as Environment Variables tend to follow SCREAMING_SNAKE_CASE instead of dot notation.
+        // So we use the constructor lexer and parser if set, otherwise the module config.
         var moduleConfig = config.getModuleConfig(EnvironmentVarsLoaderModuleConfig.class);
-        if (moduleConfig != null) {
-            if (isDefault && moduleConfig.getLexer() != null) {
+        if (moduleConfig != null && isDefault) {
+            if (moduleConfig.getLexer() != null) {
                 lexer = moduleConfig.getLexer();
             }
 
-            if (isDefault && moduleConfig.getConfigParse() != null) {
+            if (moduleConfig.getConfigParse() != null) {
                 parser = moduleConfig.getConfigParse();
             }
         }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Environment Variable Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class EnvironmentVarsLoaderModuleConfig implements GestaltModuleConfig {
+
+    private final ConfigParser parser;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Environment Variable Module.
+     *
+     * @param parser options for the ConfigParser
+     * @param lexer  the lexer to normalize paths.
+     */
+    public EnvironmentVarsLoaderModuleConfig(ConfigParser parser, SentenceLexer lexer) {
+        this.parser = parser;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "environmentVarsLoader";
+    }
+
+    /**
+     * Get the Config Parse to use with the Environment Variable module.
+     *
+     * @return Config Parse
+     */
+    public ConfigParser getConfigParse() {
+        return parser;
+    }
+
+    /**
+     * get the SentenceLexer for the Environment Variable module, used to build paths into tokens.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfigBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfigBuilder.java
@@ -8,15 +8,15 @@ import org.github.gestalt.config.parser.ConfigParser;
  *
  * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
  */
-public final class EnvironmentVarsModuleLoaderConfigBuilder {
+public final class EnvironmentVarsLoaderModuleConfigBuilder {
     private ConfigParser parser;
     private SentenceLexer lexer;
 
-    private EnvironmentVarsModuleLoaderConfigBuilder() {
+    private EnvironmentVarsLoaderModuleConfigBuilder() {
     }
 
-    public static EnvironmentVarsModuleLoaderConfigBuilder builder() {
-        return new EnvironmentVarsModuleLoaderConfigBuilder();
+    public static EnvironmentVarsLoaderModuleConfigBuilder builder() {
+        return new EnvironmentVarsLoaderModuleConfigBuilder();
     }
 
     /**
@@ -26,7 +26,7 @@ public final class EnvironmentVarsModuleLoaderConfigBuilder {
      * @param parser the Config Parse
      * @return Config Parse
      */
-    public EnvironmentVarsModuleLoaderConfigBuilder setConfigParser(ConfigParser parser) {
+    public EnvironmentVarsLoaderModuleConfigBuilder setConfigParser(ConfigParser parser) {
         this.parser = parser;
         return this;
     }
@@ -37,7 +37,7 @@ public final class EnvironmentVarsModuleLoaderConfigBuilder {
      * @param lexer SentenceLexer for the Environment Variable module.
      * @return the SentenceLexer
      */
-    public EnvironmentVarsModuleLoaderConfigBuilder setLexer(SentenceLexer lexer) {
+    public EnvironmentVarsLoaderModuleConfigBuilder setLexer(SentenceLexer lexer) {
         this.lexer = lexer;
         return this;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsModuleLoaderConfigBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/EnvironmentVarsModuleLoaderConfigBuilder.java
@@ -1,0 +1,48 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Environment Variable Module builder.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class EnvironmentVarsModuleLoaderConfigBuilder {
+    private ConfigParser parser;
+    private SentenceLexer lexer;
+
+    private EnvironmentVarsModuleLoaderConfigBuilder() {
+    }
+
+    public static EnvironmentVarsModuleLoaderConfigBuilder builder() {
+        return new EnvironmentVarsModuleLoaderConfigBuilder();
+    }
+
+    /**
+     * Set the Config Parse to use with the Environment Variable module.
+     * Used to converts the Environment Variables to a config tree.
+     *
+     * @param parser the Config Parse
+     * @return Config Parse
+     */
+    public EnvironmentVarsModuleLoaderConfigBuilder setConfigParser(ConfigParser parser) {
+        this.parser = parser;
+        return this;
+    }
+
+    /**
+     * set the SentenceLexer for the Environment Variable module, used to build paths into tokens.
+     *
+     * @param lexer SentenceLexer for the Environment Variable module.
+     * @return the SentenceLexer
+     */
+    public EnvironmentVarsModuleLoaderConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    public EnvironmentVarsLoaderModuleConfig build() {
+        return new EnvironmentVarsLoaderModuleConfig(parser, lexer);
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  */
 public final class MapConfigLoader implements ConfigLoader {
 
-    private final ConfigParser parser;
+    private ConfigParser parser;
     private SentenceLexer lexer;
     private final boolean isDefault;
 
@@ -55,11 +55,24 @@ public final class MapConfigLoader implements ConfigLoader {
         this.isDefault = isDefault;
     }
 
+
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the MapConfigLoader we will use the default gestalt sentence lexer unless set in the constructor.
+        // for the Yaml ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
+        var moduleConfig = config.getModuleConfig(MapConfigLoaderModuleConfig.class);
         if (isDefault) {
-            lexer = config.getSentenceLexer();
+            if (moduleConfig != null && moduleConfig.getLexer() != null) {
+                lexer = moduleConfig.getLexer();
+            } else {
+                lexer = config.getSentenceLexer();
+            }
+        }
+
+        if (isDefault && moduleConfig != null && moduleConfig.getConfigParse() != null) {
+            parser = moduleConfig.getConfigParse();
         }
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.loader;
 
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
@@ -15,6 +16,7 @@ import org.github.gestalt.config.utils.Pair;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Loads an in memory map from MapConfigSource.
@@ -24,13 +26,22 @@ import java.util.Map;
 public final class MapConfigLoader implements ConfigLoader {
 
     private final ConfigParser parser;
-    private final SentenceLexer lexer;
+    private SentenceLexer lexer;
+    private final boolean isDefault;
+
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the MapConfigLoader we will use the default gestalt sentence lexer.
+        if (isDefault) {
+            lexer = config.getSentenceLexer();
+        }
+    }
 
     /**
      * Construct a default Map Config loader using the default path lexer for "." separated paths.
      */
     public MapConfigLoader() {
-        this(new PathLexer("."), new MapConfigParser());
+        this(new PathLexer(), new MapConfigParser(), true);
     }
 
     /**
@@ -40,8 +51,16 @@ public final class MapConfigLoader implements ConfigLoader {
      * @param parser Parser for the Map Config files
      */
     public MapConfigLoader(SentenceLexer lexer, ConfigParser parser) {
+        this(lexer, parser, false);
+    }
+
+    private MapConfigLoader(SentenceLexer lexer, ConfigParser parser, boolean isDefault) {
+        Objects.requireNonNull(lexer, "MapConfigLoader SentenceLexer should not be null");
+        Objects.requireNonNull(parser, "MapConfigLoader ConfigParser should not be null");
+
         this.lexer = lexer;
         this.parser = parser;
+        this.isDefault = isDefault;
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoader.java
@@ -29,14 +29,6 @@ public final class MapConfigLoader implements ConfigLoader {
     private SentenceLexer lexer;
     private final boolean isDefault;
 
-    @Override
-    public void applyConfig(GestaltConfig config) {
-        // for the MapConfigLoader we will use the default gestalt sentence lexer.
-        if (isDefault) {
-            lexer = config.getSentenceLexer();
-        }
-    }
-
     /**
      * Construct a default Map Config loader using the default path lexer for "." separated paths.
      */
@@ -61,6 +53,14 @@ public final class MapConfigLoader implements ConfigLoader {
         this.lexer = lexer;
         this.parser = parser;
         this.isDefault = isDefault;
+    }
+
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the MapConfigLoader we will use the default gestalt sentence lexer unless set in the constructor.
+        if (isDefault) {
+            lexer = config.getSentenceLexer();
+        }
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoaderModuleConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoaderModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Map Loader Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class MapConfigLoaderModuleConfig implements GestaltModuleConfig {
+
+    private final ConfigParser parser;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Map Loader Module.
+     *
+     * @param parser options for the ConfigParser
+     * @param lexer  the lexer to normalize paths.
+     */
+    public MapConfigLoaderModuleConfig(ConfigParser parser, SentenceLexer lexer) {
+        this.parser = parser;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "mapLoader";
+    }
+
+    /**
+     * Get the Config Parse to use with the Map Loader module.
+     *
+     * @return Config Parse
+     */
+    public ConfigParser getConfigParse() {
+        return parser;
+    }
+
+    /**
+     * get the SentenceLexer for the Map Loader module, used to build paths into tokens.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoaderModuleConfigBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/MapConfigLoaderModuleConfigBuilder.java
@@ -1,0 +1,48 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Map Loader Module builder.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class MapConfigLoaderModuleConfigBuilder {
+    private ConfigParser parser;
+    private SentenceLexer lexer;
+
+    private MapConfigLoaderModuleConfigBuilder() {
+    }
+
+    public static MapConfigLoaderModuleConfigBuilder builder() {
+        return new MapConfigLoaderModuleConfigBuilder();
+    }
+
+    /**
+     * Set the Config Parse to use with the Map Loader module.
+     * Used to converts the Map to a config tree.
+     *
+     * @param parser the Config Parse
+     * @return Config Parse
+     */
+    public MapConfigLoaderModuleConfigBuilder setConfigParser(ConfigParser parser) {
+        this.parser = parser;
+        return this;
+    }
+
+    /**
+     * set the SentenceLexer for the Map Loader module, used to build paths into tokens.
+     *
+     * @param lexer SentenceLexer for the Map Loader module.
+     * @return the SentenceLexer
+     */
+    public MapConfigLoaderModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    public MapConfigLoaderModuleConfig build() {
+        return new MapConfigLoaderModuleConfig(parser, lexer);
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public final class PropertyLoader implements ConfigLoader {
 
-    private final ConfigParser parser;
+    private ConfigParser parser;
     private SentenceLexer lexer;
     private final boolean isDefault;
 
@@ -61,9 +61,21 @@ public final class PropertyLoader implements ConfigLoader {
 
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the PropertyLoader we will use the default gestalt sentence lexer unless set in the constructor.
+        // for the Yaml ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
+        var moduleConfig = config.getModuleConfig(PropertyLoaderModuleConfig.class);
         if (isDefault) {
-            lexer = config.getSentenceLexer();
+            if (moduleConfig != null && moduleConfig.getLexer() != null) {
+                lexer = moduleConfig.getLexer();
+            } else {
+                lexer = config.getSentenceLexer();
+            }
+        }
+
+        if (isDefault && moduleConfig != null && moduleConfig.getConfigParse() != null) {
+            parser = moduleConfig.getConfigParse();
         }
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.loader;
 
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
@@ -17,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -28,14 +30,22 @@ import java.util.stream.Collectors;
 public final class PropertyLoader implements ConfigLoader {
 
     private final ConfigParser parser;
-    private final SentenceLexer lexer;
+    private SentenceLexer lexer;
+    private final boolean isDefault;
 
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the PropertyLoader we will use the default gestalt sentence lexer.
+        if (isDefault) {
+            lexer = config.getSentenceLexer();
+        }
+    }
 
     /**
      * Construct a default property loader using the default path lexer for "." separated paths.
      */
     public PropertyLoader() {
-        this(new PathLexer("."), new MapConfigParser());
+        this(new PathLexer(), new MapConfigParser(), true);
     }
 
     /**
@@ -45,8 +55,16 @@ public final class PropertyLoader implements ConfigLoader {
      * @param parser Parser for the property files
      */
     public PropertyLoader(SentenceLexer lexer, ConfigParser parser) {
+        this(lexer, parser, false);
+    }
+
+    private PropertyLoader(SentenceLexer lexer, ConfigParser parser, boolean isDefault) {
+        Objects.requireNonNull(lexer, "PropertyLoader SentenceLexer should not be null");
+        Objects.requireNonNull(parser, "PropertyLoader ConfigParser should not be null");
+
         this.lexer = lexer;
         this.parser = parser;
+        this.isDefault = isDefault;
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
@@ -33,14 +33,6 @@ public final class PropertyLoader implements ConfigLoader {
     private SentenceLexer lexer;
     private final boolean isDefault;
 
-    @Override
-    public void applyConfig(GestaltConfig config) {
-        // for the PropertyLoader we will use the default gestalt sentence lexer.
-        if (isDefault) {
-            lexer = config.getSentenceLexer();
-        }
-    }
-
     /**
      * Construct a default property loader using the default path lexer for "." separated paths.
      */
@@ -65,6 +57,14 @@ public final class PropertyLoader implements ConfigLoader {
         this.lexer = lexer;
         this.parser = parser;
         this.isDefault = isDefault;
+    }
+
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the PropertyLoader we will use the default gestalt sentence lexer unless set in the constructor.
+        if (isDefault) {
+            lexer = config.getSentenceLexer();
+        }
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Property Loader Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class PropertyLoaderModuleConfig implements GestaltModuleConfig {
+
+    private final ConfigParser parser;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Property Loader Module.
+     *
+     * @param parser options for the ConfigParser
+     * @param lexer  the lexer to normalize paths.
+     */
+    public PropertyLoaderModuleConfig(ConfigParser parser, SentenceLexer lexer) {
+        this.parser = parser;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "propertiesLoader";
+    }
+
+    /**
+     * Get the Config Parse to use with the Property Loader module.
+     *
+     * @return Config Parse
+     */
+    public ConfigParser getConfigParse() {
+        return parser;
+    }
+
+    /**
+     * get the SentenceLexer for the Property Loader module, used to build paths into tokens.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilder.java
@@ -1,0 +1,48 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.lexer.SentenceLexer;
+import org.github.gestalt.config.parser.ConfigParser;
+
+/**
+ * Gestalt module config for the Property Loader Module builder.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class PropertyLoaderModuleConfigBuilder {
+    private ConfigParser parser;
+    private SentenceLexer lexer;
+
+    private PropertyLoaderModuleConfigBuilder() {
+    }
+
+    public static PropertyLoaderModuleConfigBuilder builder() {
+        return new PropertyLoaderModuleConfigBuilder();
+    }
+
+    /**
+     * Set the Config Parse to use with the Property Loader module.
+     * Used to converts the Property Loader to a config tree.
+     *
+     * @param parser the Config Parse
+     * @return Config Parse
+     */
+    public PropertyLoaderModuleConfigBuilder setConfigParser(ConfigParser parser) {
+        this.parser = parser;
+        return this;
+    }
+
+    /**
+     * set the SentenceLexer for the Property Loader module, used to build paths into tokens.
+     *
+     * @param lexer SentenceLexer for the Property Loader module.
+     * @return the SentenceLexer
+     */
+    public PropertyLoaderModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    public PropertyLoaderModuleConfig build() {
+        return new PropertyLoaderModuleConfig(parser, lexer);
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/path/mapper/PathMapper.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/path/mapper/PathMapper.java
@@ -8,7 +8,7 @@ import org.github.gestalt.config.utils.GResultOf;
 import java.util.List;
 
 /**
- * Interface to map a sentance to a list of tokens.
+ * Interface to map a sentence to a list of tokens.
  *
  * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
  */

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformer.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.post.process.transform;
 import org.github.gestalt.config.annotations.ConfigPriority;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.utils.SystemWrapper;
 
 /**
  * Allows you to inject Environment Variables into leaf values that match ${env:key},
@@ -21,10 +22,10 @@ public final class EnvironmentVariablesTransformer implements Transformer {
     public GResultOf<String> process(String path, String key, String rawValue) {
         if (key == null) {
             return GResultOf.errors(new ValidationError.InvalidStringSubstitutionPostProcess(path, rawValue, name()));
-        } else if (System.getenv(key) == null) {
+        } else if (SystemWrapper.getEnvVars(key) == null) {
             return GResultOf.errors(new ValidationError.NoEnvironmentVariableFoundPostProcess(path, key));
         } else {
-            return GResultOf.result(System.getenv(key));
+            return GResultOf.result(SystemWrapper.getEnvVars(key));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformerOld.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/EnvironmentVariablesTransformerOld.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.post.process.transform;
 import org.github.gestalt.config.annotations.ConfigPriority;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.utils.SystemWrapper;
 
 /**
  * Allows you to inject Environment Variables into leaf values that match ${envVar:key},
@@ -25,14 +26,14 @@ public final class EnvironmentVariablesTransformerOld implements Transformer {
     public GResultOf<String> process(String path, String key, String rawValue) {
         if (key == null) {
             return GResultOf.errors(new ValidationError.InvalidStringSubstitutionPostProcess(path, rawValue, name()));
-        } else if (System.getenv(key) == null) {
+        } else if (SystemWrapper.getEnvVars(key) == null) {
             return GResultOf.errors(new ValidationError.NoEnvironmentVariableFoundPostProcess(path, key));
         } else {
             // this class has been depricated a while, however since it is not directly exposed, no one would know that.
             // start logging warnings, so we can comfortably delete it later.
             logger.log(System.Logger.Level.WARNING,
                 "String substitutions using \"envVar\" is deprecated for removal, please use \"env\"");
-            return GResultOf.result(System.getenv(key));
+            return GResultOf.result(SystemWrapper.getEnvVars(key));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/SystemPropertiesTransformer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/SystemPropertiesTransformer.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.post.process.transform;
 import org.github.gestalt.config.annotations.ConfigPriority;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.utils.SystemWrapper;
 
 /**
  * Allows you to inject System Properties into leaf values that match ${envVar:key},
@@ -21,10 +22,10 @@ public final class SystemPropertiesTransformer implements Transformer {
     public GResultOf<String> process(String path, String key, String rawValue) {
         if (key == null) {
             return GResultOf.errors(new ValidationError.InvalidStringSubstitutionPostProcess(path, rawValue, name()));
-        } else if (!System.getProperties().containsKey(key)) {
+        } else if (!SystemWrapper.getProperties().containsKey(key)) {
             return GResultOf.errors(new ValidationError.NoSystemPropertyFoundPostProcess(path, key));
         } else {
-            return GResultOf.result(System.getProperties().get(key).toString());
+            return GResultOf.result(SystemWrapper.getProperties().get(key).toString());
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/InputStreamConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/InputStreamConfigSource.java
@@ -1,0 +1,112 @@
+package org.github.gestalt.config.source;
+
+import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.tag.Tags;
+import org.github.gestalt.config.utils.Pair;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Load a config source from an Input Stream.
+ * db.port = 1234
+ * db.password = password
+ * dp.user = notroot
+ *
+ * <p>If the format is json the string would be
+ * {
+ * db {
+ * "port" = 1234
+ * "password" = "password"
+ * "user" = "notroot"
+ * }.
+ * }
+ *
+ * <p>A format for the data in the string must also be provided.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class InputStreamConfigSource implements ConfigSource {
+    private final InputStream config;
+    private final String format;
+    private final UUID id = UUID.randomUUID();
+
+    /**
+     * Create a Configuration from a provided string. Must alos provide the format.
+     *
+     * @param config config as a string.
+     * @param format format for the string.
+     * @throws GestaltException any exception
+     */
+    public InputStreamConfigSource(InputStream config, String format) throws GestaltException {
+        this.config = config;
+        if (config == null) {
+            throw new GestaltException("The InputStream provided was null");
+        }
+
+        this.format = format;
+        if (format == null) {
+            throw new GestaltException("The InputStream format provided was null");
+        }
+    }
+
+    @Override
+    public boolean hasStream() {
+        return true;
+    }
+
+    @Override
+    public InputStream loadStream() {
+        return config;
+    }
+
+    @Override
+    public boolean hasList() {
+        return false;
+    }
+
+    @Override
+    public List<Pair<String, String>> loadList() throws GestaltException {
+        throw new GestaltException("Unsupported operation loadList on an StringConfigSource");
+    }
+
+    @Override
+    public String format() {
+        return format;
+    }
+
+
+    @Override
+    public String name() {
+        return "String format: " + format;
+    }
+
+    @Override
+    public UUID id() {  //NOPMD
+        return id;
+    }
+
+    @Override
+    public Tags getTags() {
+        return Tags.of();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof InputStreamConfigSource)) {
+            return false;
+        }
+        InputStreamConfigSource that = (InputStreamConfigSource) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/InputStreamConfigSourceBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/InputStreamConfigSourceBuilder.java
@@ -1,0 +1,80 @@
+package org.github.gestalt.config.source;
+
+import org.github.gestalt.config.builder.SourceBuilder;
+import org.github.gestalt.config.exceptions.GestaltException;
+
+import java.io.InputStream;
+
+/**
+ * ConfigSourceBuilder for the Input Stream Config Source.
+ *
+ *
+ * <p>A format for the data in the string must also be provided.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class InputStreamConfigSourceBuilder extends SourceBuilder<InputStreamConfigSourceBuilder, StringConfigSource> {
+    private InputStream config;
+    private String format;
+
+    /**
+     * private constructor, use the builder method.
+     */
+    private InputStreamConfigSourceBuilder() {
+
+    }
+
+    /**
+     * Static function to create the builder.
+     *
+     * @return the builder
+     */
+    public static InputStreamConfigSourceBuilder builder() {
+        return new InputStreamConfigSourceBuilder();
+    }
+
+    /**
+     * Get the InputStream based config source.
+     *
+     * @return the InputStream based config source
+     */
+    public InputStream getConfig() {
+        return config;
+    }
+
+    /**
+     * Set the InputStream based config source.
+     *
+     * @param config the InputStream based config source.
+     * @return the builder
+     */
+    public InputStreamConfigSourceBuilder setConfig(InputStream config) {
+        this.config = config;
+        return this;
+    }
+
+    /**
+     * Get the format the String Based Config source represents.
+     *
+     * @return the format the String Based Config source represents.
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * Set the format the String Based Config source represents.
+     *
+     * @param format the format the String Based Config source represents.
+     * @return the builder
+     */
+    public InputStreamConfigSourceBuilder setFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    @Override
+    public ConfigSourcePackage build() throws GestaltException {
+        return buildPackage(new InputStreamConfigSource(config, format));
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/SystemPropertiesConfigSource.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.source;
 import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.Pair;
+import org.github.gestalt.config.utils.SystemWrapper;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -87,7 +88,7 @@ public final class SystemPropertiesConfigSource implements ConfigSource {
 
     @Override
     public InputStream loadStream() throws GestaltException {
-        Properties properties = System.getProperties();
+        Properties properties = SystemWrapper.getProperties();
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try {
@@ -110,7 +111,7 @@ public final class SystemPropertiesConfigSource implements ConfigSource {
      */
     @Override
     public List<Pair<String, String>> loadList() {
-        Properties properties = System.getProperties();
+        Properties properties = SystemWrapper.getProperties();
 
         return properties.entrySet()
             .stream()

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/SystemWrapper.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/SystemWrapper.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.utils;
 
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Wrapper for getting the System Environments.
@@ -15,11 +16,31 @@ public final class SystemWrapper {
     }
 
     /**
-     * get the System.getenv()
+     * Returns an unmodifiable string map view of the current system environment.
+     * The environment is a system-dependent mapping from names to values which is passed from parent to child processes.
      *
      * @return the System.getenv()
      */
     public static Map<String, String> getEnvVars() {
         return System.getenv();
+    }
+
+    /**
+     * Gets the value of the specified environment variable. An environment variable is a system-dependent external named value.
+     *
+     * @param variable the environment variable to get.
+     * @return the System.getenv()
+     */
+    public static String getEnvVars(String variable) {
+        return System.getenv(variable);
+    }
+
+    /**
+     * Get the system Properties.
+     *
+     * @return the system Properties
+     */
+    public static Properties getProperties() {
+        return System.getProperties();
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
@@ -22,6 +22,11 @@ public class NoResultSentenceLexer extends SentenceLexer {
     }
 
     @Override
+    public String normalizeSentence(String sentence) {
+        return "";
+    }
+
+    @Override
     public GResultOf<List<Token>> scan(String sentence) {
         return GResultOf.result(null);
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
@@ -440,7 +440,6 @@ class EnvironmentLoaderTest {
 
     @Test
     void loadSource() throws GestaltException {
-
         Map<String, String> configMap = new HashMap<>();
 
         configMap.put("NAME", "Steve");
@@ -476,7 +475,6 @@ class EnvironmentLoaderTest {
 
     @Test
     void loadSourceModuleConfig() throws GestaltException {
-
         Map<String, String> configMap = new HashMap<>();
 
         configMap.put("NAME", "Steve");
@@ -492,7 +490,7 @@ class EnvironmentLoaderTest {
 
         var configParser = new MapConfigParser();
         var lexer = new PathLexer("_");
-        var moduleConfig = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+        var moduleConfig = EnvironmentVarsLoaderModuleConfigBuilder.builder()
             .setConfigParser(configParser)
             .setLexer(lexer)
             .build();
@@ -523,7 +521,6 @@ class EnvironmentLoaderTest {
 
     @Test
     void loadSourceModuleConfigDontFallbackToGestaltLexer() throws GestaltException {
-
         Map<String, String> configMap = new HashMap<>();
 
         configMap.put("NAME", "Steve");
@@ -535,10 +532,8 @@ class EnvironmentLoaderTest {
         configMap.put("CARS[2]_NAME", "Fiat");
         configMap.put("CARS[2]_MODELS", "500, Panda");
 
-        MapConfigSource source = new MapConfigSource(configMap);
-
         var configParser = new MapConfigParser();
-        var moduleConfig = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+        var moduleConfig = EnvironmentVarsLoaderModuleConfigBuilder.builder()
             .setConfigParser(configParser)
             //.setLexer(lexer)
             .build();
@@ -550,6 +545,7 @@ class EnvironmentLoaderTest {
         EnvironmentVarsLoader loader = new EnvironmentVarsLoader();
         loader.applyConfig(config);
 
+        MapConfigSource source = new MapConfigSource(configMap);
         GResultOf<List<ConfigNodeContainer>> resultContainer = loader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
@@ -2,15 +2,19 @@ package org.github.gestalt.config.loader;
 
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.entity.ConfigValue;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.parser.ConfigParser;
+import org.github.gestalt.config.parser.MapConfigParser;
 import org.github.gestalt.config.source.ConfigSource;
 import org.github.gestalt.config.source.ConfigSourcePackage;
+import org.github.gestalt.config.source.MapConfigSource;
 import org.github.gestalt.config.source.StringConfigSource;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.token.ObjectToken;
@@ -22,9 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.mockito.ArgumentMatchers.*;
 
@@ -60,7 +62,7 @@ class EnvironmentLoaderTest {
         Mockito.when(lexer.scan("db.name"))
             .thenReturn(GResultOf.result(List.of(new ObjectToken("db"), new ObjectToken("name"))));
 
-        // mock the source so we return our test data stream.
+        // mock the source, so we return our test data stream.
         Mockito.when(source.hasList()).thenReturn(true);
         Mockito.when(source.loadList()).thenReturn(data);
         Mockito.when(source.getTags()).thenReturn(Tags.of());
@@ -434,6 +436,136 @@ class EnvironmentLoaderTest {
         Assertions.assertInstanceOf(MapNode.class, results.results().get(0).getConfigNode());
         Assertions.assertEquals(0, ((MapNode) results.results().get(0).getConfigNode()).size());
 
+    }
+
+    @Test
+    void loadSource() throws GestaltException {
+
+        Map<String, String> configMap = new HashMap<>();
+
+        configMap.put("NAME", "Steve");
+        configMap.put("AGE", "42");
+        configMap.put("CARS[0]_NAME", "Ford");
+        configMap.put("CARS[0]_MODELS", "Fiesta, Focus, Mustang");
+        configMap.put("CARS[1]_NAME", "BMW");
+        configMap.put("CARS[1]_MODELS", "320, X3, X5");
+        configMap.put("CARS[2]_NAME", "Fiat");
+        configMap.put("CARS[2]_MODELS", "500, Panda");
+
+        MapConfigSource source = new MapConfigSource(configMap);
+
+        EnvironmentVarsLoader loader = new EnvironmentVarsLoader();
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = loader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals(3, result.getKey("cars").get().size());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta, Focus, Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getValue().get());
+
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceModuleConfig() throws GestaltException {
+
+        Map<String, String> configMap = new HashMap<>();
+
+        configMap.put("NAME", "Steve");
+        configMap.put("AGE", "42");
+        configMap.put("CARS[0]_NAME", "Ford");
+        configMap.put("CARS[0]_MODELS", "Fiesta, Focus, Mustang");
+        configMap.put("CARS[1]_NAME", "BMW");
+        configMap.put("CARS[1]_MODELS", "320, X3, X5");
+        configMap.put("CARS[2]_NAME", "Fiat");
+        configMap.put("CARS[2]_MODELS", "500, Panda");
+
+        MapConfigSource source = new MapConfigSource(configMap);
+
+        var configParser = new MapConfigParser();
+        var lexer = new PathLexer("_");
+        var moduleConfig = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+            .setConfigParser(configParser)
+            .setLexer(lexer)
+            .build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        EnvironmentVarsLoader loader = new EnvironmentVarsLoader();
+        loader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = loader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals(3, result.getKey("cars").get().size());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta, Focus, Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getValue().get());
+
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceModuleConfigDontFallbackToGestaltLexer() throws GestaltException {
+
+        Map<String, String> configMap = new HashMap<>();
+
+        configMap.put("NAME", "Steve");
+        configMap.put("AGE", "42");
+        configMap.put("CARS[0]_NAME", "Ford");
+        configMap.put("CARS[0]_MODELS", "Fiesta, Focus, Mustang");
+        configMap.put("CARS[1]_NAME", "BMW");
+        configMap.put("CARS[1]_MODELS", "320, X3, X5");
+        configMap.put("CARS[2]_NAME", "Fiat");
+        configMap.put("CARS[2]_MODELS", "500, Panda");
+
+        MapConfigSource source = new MapConfigSource(configMap);
+
+        var configParser = new MapConfigParser();
+        var moduleConfig = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+            .setConfigParser(configParser)
+            //.setLexer(lexer)
+            .build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+        config.setSentenceLexer(new PathLexer());
+
+        EnvironmentVarsLoader loader = new EnvironmentVarsLoader();
+        loader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = loader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals(3, result.getKey("cars").get().size());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta, Focus, Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getValue().get());
+
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(3).isPresent());
     }
 
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfigBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentVarsLoaderModuleConfigBuilderTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 
-class EnvironmentVarsModuleLoaderConfigBuilderTest {
+class EnvironmentVarsLoaderModuleConfigBuilderTest {
 
     @Test
     public void createModuleConfig() {
         var configParser = new MapConfigParser();
         var lexer = new PathLexer();
-        var builder = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+        var builder = EnvironmentVarsLoaderModuleConfigBuilder.builder()
             .setConfigParser(configParser)
             .setLexer(lexer);
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentVarsModuleLoaderConfigBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentVarsModuleLoaderConfigBuilderTest.java
@@ -1,0 +1,29 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltConfig;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.parser.MapConfigParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class EnvironmentVarsModuleLoaderConfigBuilderTest {
+
+    @Test
+    public void createModuleConfig() {
+        var configParser = new MapConfigParser();
+        var lexer = new PathLexer();
+        var builder = EnvironmentVarsModuleLoaderConfigBuilder.builder()
+            .setConfigParser(configParser)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        Assertions.assertEquals(configParser, moduleConfig.getConfigParse());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("environmentVarsLoader", moduleConfig.name());
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapLoaderModuleConfigBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapLoaderModuleConfigBuilderTest.java
@@ -1,0 +1,29 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltConfig;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.parser.MapConfigParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class MapLoaderModuleConfigBuilderTest {
+
+    @Test
+    public void createModuleConfig() {
+        var configParser = new MapConfigParser();
+        var lexer = new PathLexer();
+        var builder = MapConfigLoaderModuleConfigBuilder.builder()
+            .setConfigParser(configParser)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        Assertions.assertEquals(configParser, moduleConfig.getConfigParse());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("mapLoader", moduleConfig.name());
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilderTest.java
@@ -1,0 +1,29 @@
+package org.github.gestalt.config.loader;
+
+import org.github.gestalt.config.entity.GestaltConfig;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.parser.MapConfigParser;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class PropertyLoaderModuleConfigBuilderTest {
+
+    @Test
+    public void createModuleConfig() {
+        var configParser = new MapConfigParser();
+        var lexer = new PathLexer();
+        var builder = PropertyLoaderModuleConfigBuilder.builder()
+            .setConfigParser(configParser)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        Assertions.assertEquals(configParser, moduleConfig.getConfigParse());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("propertiesLoader", moduleConfig.name());
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/source/InputStreamConfigSourceBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/source/InputStreamConfigSourceBuilderTest.java
@@ -1,0 +1,81 @@
+package org.github.gestalt.config.source;
+
+import org.github.gestalt.config.exceptions.GestaltException;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InputStreamConfigSourceBuilderTest {
+
+    @Test
+    void buildStringConfigSource() throws GestaltException {
+        String config = "db.port = 1234\ndb.password = password\ndb.user = notroot";
+        String format = "properties";
+
+        InputStreamConfigSourceBuilder builder = InputStreamConfigSourceBuilder.builder();
+        builder.setConfig(new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)))
+            .setFormat(format);
+
+        assertNotNull(builder.getConfig());
+        assertEquals(format, builder.getFormat());
+        ConfigSourcePackage configSourcePackage = builder.build();
+
+        assertNotNull(configSourcePackage);
+        assertNotNull(configSourcePackage.getConfigSource());
+
+        InputStreamConfigSource stringConfigSource = (InputStreamConfigSource) configSourcePackage.getConfigSource();
+        assertTrue(stringConfigSource.hasStream());
+        assertEquals(format, stringConfigSource.format());
+    }
+
+    @Test
+    void buildStringConfigSourceNullConfig() {
+        // Arrange
+        String format = "properties";
+
+        InputStreamConfigSourceBuilder builder = InputStreamConfigSourceBuilder.builder();
+        builder.setFormat(format);
+
+        // Act and Assert
+        GestaltException e = assertThrows(GestaltException.class, builder::build);
+        assertEquals("The InputStream provided was null", e.getMessage());
+    }
+
+    @Test
+    void buildStringConfigSourceNullFormat() {
+        // Arrange
+        String config = "db.port = 1234\ndb.password = password\ndb.user = notroot";
+
+        InputStreamConfigSourceBuilder builder = InputStreamConfigSourceBuilder.builder();
+        builder.setConfig(new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)));
+
+        // Act and Assert
+        GestaltException e = assertThrows(GestaltException.class, builder::build);
+        assertEquals("The InputStream format provided was null", e.getMessage());
+    }
+
+    @Test
+    void buildStringConfigSourceEmptyConfig() throws GestaltException {
+        // Arrange
+        String config = "";
+        String format = "properties";
+
+        InputStreamConfigSourceBuilder builder = InputStreamConfigSourceBuilder.builder();
+        builder.setConfig(new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8)))
+            .setFormat(format);
+
+        // Act
+        ConfigSourcePackage configSourcePackage = builder.build();
+
+        // Assert
+        assertNotNull(configSourcePackage);
+        assertNotNull(configSourcePackage.getConfigSource());
+
+        InputStreamConfigSource stringConfigSource = (InputStreamConfigSource) configSourcePackage.getConfigSource();
+        assertTrue(stringConfigSource.hasStream());
+        assertEquals(format, stringConfigSource.format());
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/source/InputStreamConfigSourceTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/source/InputStreamConfigSourceTest.java
@@ -1,0 +1,100 @@
+package org.github.gestalt.config.source;
+
+import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.tag.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+class InputStreamConfigSourceTest {
+
+    @Test
+    void loadFile() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertTrue(source.hasStream());
+        Assertions.assertNotNull(source.loadStream());
+    }
+
+    @Test
+    void loadStringNull() {
+        GestaltException exception = Assertions.assertThrows(GestaltException.class, () -> new InputStreamConfigSource(null, "properties"));
+
+        Assertions.assertEquals("The InputStream provided was null", exception.getMessage());
+    }
+
+    @Test
+    void loadFormatNull() {
+        GestaltException exception = Assertions.assertThrows(GestaltException.class,
+            () -> new InputStreamConfigSource(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), null));
+
+        Assertions.assertEquals("The InputStream format provided was null", exception.getMessage());
+    }
+
+
+    @Test
+    void fileType() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertEquals("properties", source.format());
+    }
+
+    @Test
+    void fileTypeJson() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "json");
+
+        Assertions.assertEquals("json", source.format());
+    }
+
+    @Test
+    void name() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertEquals("String format: properties", source.name());
+    }
+
+    @Test
+    void unsupportedList() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertFalse(source.hasList());
+        Assertions.assertThrows(GestaltException.class, source::loadList);
+    }
+
+    @Test
+    void equals() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        InputStreamConfigSource source2 = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertEquals(source, source);
+        Assertions.assertNotEquals(source, source2);
+        Assertions.assertNotEquals(source, null);
+        Assertions.assertNotEquals(source, 1L);
+    }
+
+    @Test
+    void hash() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+
+        Assertions.assertTrue(source.hashCode() != 0);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void tags() throws GestaltException {
+        InputStreamConfigSource source = new InputStreamConfigSource(
+            new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)), "properties");
+        Assertions.assertEquals(Tags.of(), source.getTags());
+    }
+}

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
@@ -62,7 +62,10 @@ public final class HoconLoader implements ConfigLoader {
 
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the Hocon ConfigLoader we will use the default gestalt sentence lexer.
+        // for the Hocon ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
         var moduleConfig = config.getModuleConfig(HoconModuleConfig.class);
         if (isDefault) {
             if (moduleConfig != null && moduleConfig.getLexer() != null) {

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
@@ -2,16 +2,19 @@ package org.github.gestalt.config.hocon;
 
 import com.typesafe.config.*;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.loader.ConfigLoader;
 import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.source.ConfigSourcePackage;
-import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.utils.PathUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,24 +30,52 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class HoconLoader implements ConfigLoader {
 
-    private final ConfigParseOptions configParseOptions;
+    private final boolean isDefault;
+    private ConfigParseOptions configParseOptions;
+    private SentenceLexer lexer;
 
     /**
      * Default constructor for HoconLoader that uses the default ConfigParseOptions.
      */
     public HoconLoader() {
-        configParseOptions = ConfigParseOptions.defaults();
+        this(ConfigParseOptions.defaults(), new PathLexer(), true);
     }
 
     /**
      * Constructor for HoconLoader that accepts a ConfigParseOptions.
      *
      * @param configParseOptions options for the Hocon parsing
+     * @param lexer              the lexer to normalize paths.
      */
-    public HoconLoader(ConfigParseOptions configParseOptions) {
-        this.configParseOptions = configParseOptions;
+    public HoconLoader(ConfigParseOptions configParseOptions, SentenceLexer lexer) {
+        this(configParseOptions, lexer, false);
     }
 
+    private HoconLoader(ConfigParseOptions configParseOptions, SentenceLexer lexer, boolean isDefault) {
+        Objects.requireNonNull(lexer, "HoconLoader SentenceLexer should not be null");
+        Objects.requireNonNull(configParseOptions, "HoconLoader ConfigParseOptions should not be null");
+
+        this.configParseOptions = configParseOptions;
+        this.lexer = lexer;
+        this.isDefault = isDefault;
+    }
+
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the Hocon ConfigLoader we will use the default gestalt sentence lexer.
+        var moduleConfig = config.getModuleConfig(HoconModuleConfig.class);
+        if (isDefault) {
+            if (moduleConfig != null && moduleConfig.getLexer() != null) {
+                lexer = moduleConfig.getLexer();
+            } else {
+                lexer = config.getSentenceLexer();
+            }
+        }
+
+        if (isDefault && moduleConfig != null && moduleConfig.getConfigParseOptions() != null) {
+            configParseOptions = moduleConfig.getConfigParseOptions();
+        }
+    }
 
     @Override
     public String name() {
@@ -109,7 +140,7 @@ public final class HoconLoader implements ConfigLoader {
     }
 
     private String normalizeSentence(String sentence) {
-        return sentence.toLowerCase(Locale.getDefault());
+        return lexer.normalizeSentence(sentence);
     }
 
     private GResultOf<ConfigNode> buildArrayConfigTree(String path, ConfigList configList) {

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconModuleConfig.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.hocon;
+
+import com.typesafe.config.ConfigParseOptions;
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Gestalt module config for the Hocon Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class HoconModuleConfig implements GestaltModuleConfig {
+
+    private final ConfigParseOptions configParseOptions;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Hocon Module.
+     *
+     * @param configParseOptions options for the Hocon parsing
+     * @param lexer        the lexer to normalize paths.
+     */
+    public HoconModuleConfig(ConfigParseOptions configParseOptions, SentenceLexer lexer) {
+        this.configParseOptions = configParseOptions;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "hocon";
+    }
+
+    /**
+     * Get the Config Parse Options to use with the Hocon module.
+     *
+     * @return Config Parse Options
+     */
+    public ConfigParseOptions getConfigParseOptions() {
+        return configParseOptions;
+    }
+
+    /**
+     * get the SentenceLexer for the Hocon module, used to normalize sentences.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconModuleConfigBuilder.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconModuleConfigBuilder.java
@@ -1,0 +1,59 @@
+package org.github.gestalt.config.hocon;
+
+import com.typesafe.config.ConfigParseOptions;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Builder to build a Json ModuleConfig.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class HoconModuleConfigBuilder {
+    private ConfigParseOptions configParseOptions;
+    private SentenceLexer lexer;
+
+    private HoconModuleConfigBuilder() {
+    }
+
+    /**
+     * Get the builder for the Hocon Module Config.
+     *
+     * @return the builder
+     */
+    public static HoconModuleConfigBuilder builder() {
+        return new HoconModuleConfigBuilder();
+    }
+
+    /**
+     * Set the config Parse Options to use for this Hocon Module.
+     *
+     * @param configParseOptions the config Parse Options
+     * @return the builder
+     */
+    public HoconModuleConfigBuilder setConfigParseOptions(ConfigParseOptions configParseOptions) {
+        this.configParseOptions = configParseOptions;
+        return this;
+    }
+
+    /**
+     * Set the Lexer used to normalize the paths in the Json Module.
+     * If not set it defaults to the one set in gestalt.
+     * It is not recommended to set this lexer unless you want custom behaviour for this module. Preferably use the Gestalt Config one.
+     *
+     * @param lexer lexer used to normalize the paths.
+     * @return the builder
+     */
+    public HoconModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    /**
+     * build the Hocon ModuleConfig.
+     *
+     * @return the Hocon ModuleConfig
+     */
+    public HoconModuleConfig build() {
+        return new HoconModuleConfig(configParseOptions, lexer);
+    }
+}

--- a/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconModuleConfigTest.java
+++ b/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconModuleConfigTest.java
@@ -1,0 +1,25 @@
+package org.github.gestalt.config.hocon;
+
+import com.typesafe.config.ConfigParseOptions;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class HoconModuleConfigTest {
+
+    @Test
+    public void createModuleConfig() {
+        var configParser = ConfigParseOptions.defaults();
+        var lexer = new PathLexer();
+        var builder = HoconModuleConfigBuilder.builder()
+            .setConfigParseOptions(configParser)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        Assertions.assertEquals(configParser, moduleConfig.getConfigParseOptions());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("hocon", moduleConfig.name());
+    }
+}

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
@@ -62,7 +62,10 @@ public final class JsonLoader implements ConfigLoader {
 
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the Json ConfigLoader we will use the default gestalt sentence lexer.
+        // for the Json ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
         var moduleConfig = config.getModuleConfig(JsonModuleConfig.class);
         if (isDefault) {
             if (moduleConfig != null && moduleConfig.getLexer() != null) {

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonModuleConfig.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Gestalt module config for the Json Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class JsonModuleConfig implements GestaltModuleConfig {
+
+    private final ObjectMapper objectMapper;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Json Module.
+     *
+     * @param objectMapper for loading yaml config, it should have a YAMLFactory registered to it.
+     * @param lexer        the lexer to normalize paths.
+     */
+    public JsonModuleConfig(ObjectMapper objectMapper, SentenceLexer lexer) {
+        this.objectMapper = objectMapper;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "json";
+    }
+
+    /**
+     * Get the object mapper to use with the Json module.
+     *
+     * @return object mapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    /**
+     * get the SentenceLexer for the Json module, used to normalize sentences.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonModuleConfigBuilder.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonModuleConfigBuilder.java
@@ -1,0 +1,59 @@
+package org.github.gestalt.config.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Builder to build a Json ModuleConfig.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class JsonModuleConfigBuilder {
+    private ObjectMapper objectMapper;
+    private SentenceLexer lexer;
+
+    private JsonModuleConfigBuilder() {
+    }
+
+    /**
+     * Get the builder for the Json Module Config.
+     *
+     * @return the builder
+     */
+    public static JsonModuleConfigBuilder builder() {
+        return new JsonModuleConfigBuilder();
+    }
+
+    /**
+     * Set the object mapper to use for this Json Module.
+     *
+     * @param objectMapper the object mapper
+     * @return the builder
+     */
+    public JsonModuleConfigBuilder setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    /**
+     * Set the Lexer used to normalize the paths in the Json Module.
+     * If not set it defaults to the one set in gestalt.
+     * It is not recommended to set this lexer unless you want custom behaviour for this module. Preferably use the Gestalt Config one.
+     *
+     * @param lexer lexer used to normalize the paths.
+     * @return the builder
+     */
+    public JsonModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    /**
+     * build the Json ModuleConfig.
+     *
+     * @return the Json ModuleConfig
+     */
+    public JsonModuleConfig build() {
+        return new JsonModuleConfig(objectMapper, lexer);
+    }
+}

--- a/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
+++ b/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
@@ -122,6 +122,55 @@ class JsonLoaderTest {
     }
 
     @Test
+    void loadSourceModuleConfigConstructor() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("{\n" +
+            "  \"name\":\"Steve\",\n" +
+            "  \"age\":42,\n" +
+            "  \"cars\": [\n" +
+            "    { \"name\":\"Ford\", \"models\":[ \"Fiesta\", \"Focus\", \"Mustang\" ] },\n" +
+            "    { \"name\":\"BMW\", \"models\":[ \"320\", \"X3\", \"X5\" ] },\n" +
+            "    { \"name\":\"Fiat\", \"models\":[ \"500\", \"Panda\" ] }\n" +
+            "  ]\n" +
+            " } ", "json");
+
+        JsonLoader jsonLoader = new JsonLoader(new ObjectMapper(), new PathLexer());
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper().findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = JsonModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+
+        jsonLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @SuppressWarnings("VariableDeclarationUsageDistance")
+    @Test
     void loadSourceModuleConfigGestaltConfigLexer() throws GestaltException {
 
         StringConfigSource source = new StringConfigSource("{\n" +

--- a/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
+++ b/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
@@ -2,7 +2,9 @@ package org.github.gestalt.config.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
@@ -45,6 +47,10 @@ class JsonLoaderTest {
             " } ", "json");
 
         JsonLoader jsonLoader = new JsonLoader();
+        GestaltConfig config = new GestaltConfig();
+        config.setSentenceLexer(new PathLexer());
+
+        jsonLoader.applyConfig(config);
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
@@ -67,7 +73,8 @@ class JsonLoaderTest {
                                      .get().getIndex(3).isPresent());
     }
 
-    void loadSourceWithTags() throws GestaltException {
+    @Test
+    void loadSourceModuleConfig() throws GestaltException {
 
         StringConfigSource source = new StringConfigSource("{\n" +
             "  \"name\":\"Steve\",\n" +
@@ -80,6 +87,18 @@ class JsonLoaderTest {
             " } ", "json");
 
         JsonLoader jsonLoader = new JsonLoader();
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper().findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = JsonModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+
+        jsonLoader.applyConfig(config);
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
@@ -87,19 +106,68 @@ class JsonLoaderTest {
         Assertions.assertTrue(resultContainer.hasResults());
         ConfigNode result = resultContainer.results().get(0).getConfigNode();
 
-        Assertions.assertEquals(Tags.of("toy", "ball"), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
         Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
         Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
         Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
-                                              .get().getValue().get());
+            .get().getValue().get());
         Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
-                                                .get().getIndex(0).get().getValue().get());
+            .get().getIndex(0).get().getValue().get());
         Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
-                                               .get().getIndex(1).get().getValue().get());
+            .get().getIndex(1).get().getValue().get());
         Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
-                                                 .get().getIndex(2).get().getValue().get());
+            .get().getIndex(2).get().getValue().get());
         Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
-                                     .get().getIndex(3).isPresent());
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceModuleConfigGestaltConfigLexer() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("{\n" +
+            "  \"name\":\"Steve\",\n" +
+            "  \"age\":42,\n" +
+            "  \"cars\": [\n" +
+            "    { \"name\":\"Ford\", \"models\":[ \"Fiesta\", \"Focus\", \"Mustang\" ] },\n" +
+            "    { \"name\":\"BMW\", \"models\":[ \"320\", \"X3\", \"X5\" ] },\n" +
+            "    { \"name\":\"Fiat\", \"models\":[ \"500\", \"Panda\" ] }\n" +
+            "  ]\n" +
+            " } ", "json");
+
+        JsonLoader jsonLoader = new JsonLoader();
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper().findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = JsonModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            //.setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+        config.setSentenceLexer(lexer);
+
+        jsonLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
     }
 
     @Test
@@ -150,7 +218,7 @@ class JsonLoaderTest {
             "  ]\n" +
             " } ", "json");
 
-        JsonLoader jsonLoader = new JsonLoader(new ObjectMapper());
+        JsonLoader jsonLoader = new JsonLoader(new ObjectMapper(), new PathLexer());
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
         Assertions.assertFalse(resultContainer.hasErrors());

--- a/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonModuleConfigTest.java
+++ b/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonModuleConfigTest.java
@@ -1,0 +1,25 @@
+package org.github.gestalt.config.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class JsonModuleConfigTest {
+
+    @Test
+    public void createModuleConfig() {
+        var objectMapper = new ObjectMapper().findAndRegisterModules();
+        var lexer = new PathLexer();
+        var builder = JsonModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        Assertions.assertEquals(objectMapper, moduleConfig.getObjectMapper());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("json", moduleConfig.name());
+    }
+}

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
@@ -62,7 +62,10 @@ public final class TomlLoader implements ConfigLoader {
 
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the Toml ConfigLoader we will use the default gestalt sentence lexer.
+        // for the Toml ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
         var moduleConfig = config.getModuleConfig(TomlModuleConfig.class);
         if (isDefault) {
             if (moduleConfig != null && moduleConfig.getLexer() != null) {

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlModuleConfig.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.toml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Gestalt module config for the Toml Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class TomlModuleConfig implements GestaltModuleConfig {
+
+    private final ObjectMapper objectMapper;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Toml Module.
+     *
+     * @param objectMapper for loading yaml config, it should have a YAMLFactory registered to it.
+     * @param lexer        the lexer to normalize paths.
+     */
+    public TomlModuleConfig(ObjectMapper objectMapper, SentenceLexer lexer) {
+        this.objectMapper = objectMapper;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "toml";
+    }
+
+    /**
+     * Get the object mapper to use with the Toml module.
+     *
+     * @return object mapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    /**
+     * get the SentenceLexer for the Toml module, used to normalize sentences.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlModuleConfigBuilder.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlModuleConfigBuilder.java
@@ -1,0 +1,59 @@
+package org.github.gestalt.config.toml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Builder to build a Toml ModuleConfig.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class TomlModuleConfigBuilder {
+    private ObjectMapper objectMapper;
+    private SentenceLexer lexer;
+
+    private TomlModuleConfigBuilder() {
+    }
+
+    /**
+     * Get the builder for the Toml Module Config.
+     *
+     * @return the builder
+     */
+    public static TomlModuleConfigBuilder builder() {
+        return new TomlModuleConfigBuilder();
+    }
+
+    /**
+     * Set the object mapper to use for this Toml Module.
+     *
+     * @param objectMapper the object mapper
+     * @return the builder
+     */
+    public TomlModuleConfigBuilder setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    /**
+     * Set the Lexer used to normalize the paths in the Toml Module.
+     * If not set it defaults to the one set in gestalt.
+     * It is not recommended to set this lexer unless you want custom behaviour for this module. Preferably use the Gestalt Config one.
+     *
+     * @param lexer lexer used to normalize the paths.
+     * @return the builder
+     */
+    public TomlModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    /**
+     * build the Toml ModuleConfig.
+     *
+     * @return the Toml ModuleConfig
+     */
+    public TomlModuleConfig build() {
+        return new TomlModuleConfig(objectMapper, lexer);
+    }
+}

--- a/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
+++ b/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
@@ -132,6 +132,58 @@ class TomlLoaderTest {
     }
 
     @Test
+    void loadSourceWithModuleConfigConstructor() throws GestaltException {
+        var lexer = new PathLexer();
+        var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();
+
+        var moduleConfig = TomlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        TomlLoader tomlLoader = new TomlLoader(new ObjectMapper(new TomlFactory()).findAndRegisterModules(), new PathLexer());
+        tomlLoader.applyConfig(config);
+
+        StringConfigSource source = new StringConfigSource("name = \"Steve\" \n" +
+            "age = 42\n" +
+
+            "[[cars]]\n" +
+            "name = \"Ford\"\n" +
+            "models = [ \"Fiesta\", \"Focus\", \"Mustang\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"BMW\"\n" +
+            "models = [ \"320\", \"X3\", \"X5\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"Fiat\"\n" +
+            "models = [ \"500\", \"Panda\" ]\n", "toml");
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceWithModuleConfigGestaltConfigLexer() throws GestaltException {
         var lexer = new PathLexer();
         var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();

--- a/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
+++ b/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
@@ -3,7 +3,9 @@ package org.github.gestalt.config.toml;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.toml.TomlFactory;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
@@ -52,6 +54,11 @@ class TomlLoaderTest {
 
         TomlLoader tomlLoader = new TomlLoader();
 
+        GestaltConfig config = new GestaltConfig();
+        config.setSentenceLexer(new PathLexer());
+
+        tomlLoader.applyConfig(config);
+
         GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
         Assertions.assertFalse(resultContainer.hasErrors());
@@ -70,6 +77,110 @@ class TomlLoaderTest {
                                                  .get().getIndex(2).get().getValue().get());
         Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
                                      .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceWithModuleConfig() throws GestaltException {
+        var lexer = new PathLexer();
+        var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();
+
+        var moduleConfig = TomlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+
+        TomlLoader tomlLoader = new TomlLoader();
+        tomlLoader.applyConfig(config);
+
+        StringConfigSource source = new StringConfigSource("name = \"Steve\" \n" +
+            "age = 42\n" +
+
+            "[[cars]]\n" +
+            "name = \"Ford\"\n" +
+            "models = [ \"Fiesta\", \"Focus\", \"Mustang\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"BMW\"\n" +
+            "models = [ \"320\", \"X3\", \"X5\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"Fiat\"\n" +
+            "models = [ \"500\", \"Panda\" ]\n", "toml");
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceWithModuleConfigGestaltConfigLexer() throws GestaltException {
+        var lexer = new PathLexer();
+        var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();
+
+        var moduleConfig = TomlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            //.setLexer(lexer)
+            .build();
+
+        GestaltConfig config = new GestaltConfig();
+        config.registerModuleConfig(moduleConfig);
+        config.setSentenceLexer(lexer);
+
+        TomlLoader tomlLoader = new TomlLoader();
+        tomlLoader.applyConfig(config);
+
+        StringConfigSource source = new StringConfigSource("name = \"Steve\" \n" +
+            "age = 42\n" +
+
+            "[[cars]]\n" +
+            "name = \"Ford\"\n" +
+            "models = [ \"Fiesta\", \"Focus\", \"Mustang\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"BMW\"\n" +
+            "models = [ \"320\", \"X3\", \"X5\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"Fiat\"\n" +
+            "models = [ \"500\", \"Panda\" ]\n", "toml");
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
     }
 
     @Test
@@ -130,7 +241,7 @@ class TomlLoaderTest {
             "name = \"Fiat\"\n" +
             "models = [ \"500\", \"Panda\" ]\n", "toml");
 
-        TomlLoader tomlLoader = new TomlLoader(new ObjectMapper(new TomlFactory()));
+        TomlLoader tomlLoader = new TomlLoader(new ObjectMapper(new TomlFactory()), new PathLexer());
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
@@ -150,6 +261,76 @@ class TomlLoaderTest {
                                                  .get().getIndex(2).get().getValue().get());
         Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
                                      .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceTomlSample() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("\n" +
+            "\n" +
+            "# This is a TOML document\n" +
+            "\n" +
+            "title = \"TOML Example\"\n" +
+            "\n" +
+            "[owner]\n" +
+            "name = \"Tom Preston-Werner\"\n" +
+            "dob = 1979-05-27T07:32:00-08:00\n" +
+            "\n" +
+            "[database]\n" +
+            "enabled = true\n" +
+            "ports = [ 8000, 8001, 8002 ]\n" +
+            "data = [ [\"delta\", \"phi\"], [3.14] ]\n" +
+            "temp_targets = { cpu = 79.5, case = 72.0 }\n" +
+            "\n" +
+            "[servers]\n" +
+            "\n" +
+            "[servers.alpha]\n" +
+            "ip = \"10.0.0.1\"\n" +
+            "role = \"frontend\"\n" +
+            "\n" +
+            "[servers.beta]\n" +
+            "ip = \"10.0.0.2\"\n" +
+            "role = \"backend\"\n" +
+            "\n", "toml");
+
+        TomlLoader tomlLoader = new TomlLoader(new ObjectMapper(new TomlFactory()), new PathLexer());
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Tom Preston-Werner", result.getKey("owner").get().getKey("name").get().getValue().get());
+        Assertions.assertEquals("1979-05-27T07:32:00-08:00", result.getKey("owner").get().getKey("dob").get().getValue().get());
+
+        Assertions.assertEquals("true", result.getKey("database").get().getKey("enabled").get().getValue().get());
+        Assertions.assertEquals("8000", result.getKey("database").get().getKey("ports").get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("8001", result.getKey("database").get().getKey("ports").get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("8002", result.getKey("database").get().getKey("ports").get().getIndex(2).get().getValue().get());
+
+        Assertions.assertEquals("delta", result.getKey("database").get().getKey("data").get().getIndex(0).get().getIndex(0).get()
+            .getValue().get());
+        Assertions.assertEquals("phi", result.getKey("database").get().getKey("data").get().getIndex(0).get().getIndex(1).get()
+            .getValue().get());
+        Assertions.assertEquals("3.14", result.getKey("database").get().getKey("data").get().getIndex(1).get().getIndex(0).get()
+            .getValue().get());
+
+        Assertions.assertEquals("79.5", result.getKey("database").get().getKey("temp_targets").get().getKey("cpu").get()
+            .getValue().get());
+        Assertions.assertEquals("72", result.getKey("database").get().getKey("temp_targets").get().getKey("case").get()
+            .getValue().get());
+
+        Assertions.assertEquals("10.0.0.1", result.getKey("servers").get().getKey("alpha").get().getKey("ip").get() //NOPMD
+            .getValue().get());
+        Assertions.assertEquals("frontend", result.getKey("servers").get().getKey("alpha").get().getKey("role").get()
+            .getValue().get());
+
+
+        Assertions.assertEquals("10.0.0.2", result.getKey("servers").get().getKey("beta").get().getKey("ip").get()  //NOPMD
+            .getValue().get());
+        Assertions.assertEquals("backend", result.getKey("servers").get().getKey("beta").get().getKey("role").get()
+            .getValue().get());
     }
 
     @Test

--- a/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlModuleConfigTest.java
+++ b/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlModuleConfigTest.java
@@ -1,0 +1,26 @@
+package org.github.gestalt.config.toml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.toml.TomlFactory;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class TomlModuleConfigTest {
+
+    @Test
+    public void createModuleConfig() {
+        var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();
+        var lexer = new PathLexer();
+        var builder = TomlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        Assertions.assertEquals(objectMapper, moduleConfig.getObjectMapper());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("toml", moduleConfig.name());
+    }
+}

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
@@ -63,7 +63,10 @@ public final class YamlLoader implements ConfigLoader {
 
     @Override
     public void applyConfig(GestaltConfig config) {
-        // for the yaml ConfigLoader we will use the default gestalt sentence lexer.
+        // for the Yaml ConfigLoader we will use the lexer in the following priorities
+        // 1. the constructor
+        // 2. the module config
+        // 3. the Gestalt Configuration
         var moduleConfig = config.getModuleConfig(YamlModuleConfig.class);
         if (isDefault) {
             if (moduleConfig != null && moduleConfig.getLexer() != null) {

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
@@ -4,16 +4,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.loader.ConfigLoader;
 import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.source.ConfigSourcePackage;
-import org.github.gestalt.config.utils.PathUtil;
 import org.github.gestalt.config.utils.GResultOf;
+import org.github.gestalt.config.utils.PathUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,24 +31,53 @@ import static com.fasterxml.jackson.databind.node.JsonNodeType.MISSING;
  */
 public final class YamlLoader implements ConfigLoader {
 
-    private final ObjectMapper objectMapper;
-
-    /**
-     * Constructor for YamlLoader that accepts a ObjectMapper.
-     *
-     * @param objectMapper for loading yaml config, it should have a YAMLFactory registered to it.
-     */
-    public YamlLoader(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
+    private final boolean isDefault;
+    private ObjectMapper objectMapper;
+    private SentenceLexer lexer;
 
     /**
      * Default constructor for YamlLoader that creates a new ObjectMapper with a YAMLFactory registered to it.
      */
     public YamlLoader() {
-        objectMapper = new ObjectMapper(new YAMLFactory());
-        objectMapper.findAndRegisterModules();
+        this(new ObjectMapper(new YAMLFactory()).findAndRegisterModules(), new PathLexer(), true);
     }
+
+    /**
+     * Constructor for YamlLoader that accepts a ObjectMapper.
+     *
+     * @param objectMapper for loading yaml config, it should have a YAMLFactory registered to it.
+     * @param lexer        the lexer to normalize paths.
+     */
+    public YamlLoader(ObjectMapper objectMapper, SentenceLexer lexer) {
+        this(objectMapper, lexer, false);
+    }
+
+    public YamlLoader(ObjectMapper objectMapper, SentenceLexer lexer, boolean isDefault) {
+        Objects.requireNonNull(lexer, "YamlLoader SentenceLexer should not be null");
+        Objects.requireNonNull(objectMapper, "YamlLoader ObjectMapper should not be null");
+
+        this.objectMapper = objectMapper;
+        this.lexer = lexer;
+        this.isDefault = isDefault;
+    }
+
+    @Override
+    public void applyConfig(GestaltConfig config) {
+        // for the yaml ConfigLoader we will use the default gestalt sentence lexer.
+        var moduleConfig = config.getModuleConfig(YamlModuleConfig.class);
+        if (isDefault) {
+            if (moduleConfig != null && moduleConfig.getLexer() != null) {
+                lexer = moduleConfig.getLexer();
+            } else {
+                lexer = config.getSentenceLexer();
+            }
+        }
+
+        if (isDefault && moduleConfig != null && moduleConfig.getObjectMapper() != null) {
+            objectMapper = moduleConfig.getObjectMapper();
+        }
+    }
+
 
     @Override
     public String name() {
@@ -115,7 +147,7 @@ public final class YamlLoader implements ConfigLoader {
     }
 
     private String normalizeSentence(String sentence) {
-        return sentence.toLowerCase(Locale.getDefault());
+        return lexer.normalizeSentence(sentence);
     }
 
     private GResultOf<ConfigNode> buildArrayConfigTree(String path, JsonNode jsonNode) {

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlModuleConfig.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlModuleConfig.java
@@ -1,0 +1,50 @@
+package org.github.gestalt.config.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.entity.GestaltModuleConfig;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Gestalt module config for the Yaml Module.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public class YamlModuleConfig implements GestaltModuleConfig {
+
+    private final ObjectMapper objectMapper;
+    private final SentenceLexer lexer;
+
+    /**
+     * Gestalt module config for the Yaml Module.
+     *
+     * @param objectMapper for loading yaml config, it should have a YAMLFactory registered to it.
+     * @param lexer        the lexer to normalize paths.
+     */
+    public YamlModuleConfig(ObjectMapper objectMapper, SentenceLexer lexer) {
+        this.objectMapper = objectMapper;
+        this.lexer = lexer;
+    }
+
+    @Override
+    public String name() {
+        return "yaml";
+    }
+
+    /**
+     * Get the object mapper to use with the Yaml module.
+     *
+     * @return object mapper
+     */
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    /**
+     * get the SentenceLexer for the Yaml module, used to normalize sentences.
+     *
+     * @return the SentenceLexer
+     */
+    public SentenceLexer getLexer() {
+        return lexer;
+    }
+}

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlModuleConfigBuilder.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlModuleConfigBuilder.java
@@ -1,0 +1,59 @@
+package org.github.gestalt.config.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.github.gestalt.config.lexer.SentenceLexer;
+
+/**
+ * Builder to build a YamlModuleConfig.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class YamlModuleConfigBuilder {
+    private ObjectMapper objectMapper;
+    private SentenceLexer lexer;
+
+    private YamlModuleConfigBuilder() {
+    }
+
+    /**
+     * Get the builder for the Yaml Module Config.
+     *
+     * @return the builder
+     */
+    public static YamlModuleConfigBuilder builder() {
+        return new YamlModuleConfigBuilder();
+    }
+
+    /**
+     * Set the object mapper to use for this Yaml Module.
+     *
+     * @param objectMapper the object mapper
+     * @return the builder
+     */
+    public YamlModuleConfigBuilder setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    /**
+     * Set the Lexer used to normalize the paths in the Yaml Module.
+     * If not set it defaults to the one set in gestalt.
+     * It is not recommended to set this lexer unless you want custom behaviour for this module. Preferably use the Gestalt Config one.
+     *
+     * @param lexer lexer used to normalize the paths.
+     * @return the builder
+     */
+    public YamlModuleConfigBuilder setLexer(SentenceLexer lexer) {
+        this.lexer = lexer;
+        return this;
+    }
+
+    /**
+     * build the Yaml ModuleConfig.
+     *
+     * @return the Yaml ModuleConfig
+     */
+    public YamlModuleConfig build() {
+        return new YamlModuleConfig(objectMapper, lexer);
+    }
+}

--- a/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
+++ b/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
@@ -122,6 +122,53 @@ class YamlLoaderTest {
     }
 
     @Test
+    void loadSourceModuleConfigConstructor() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("name: Steve\n" +
+            "age: 42\n" +
+            "cars: \n" +
+            "  - name: Ford\n" +
+            "    models: [Fiesta, Focus, Mustang]\n" +
+            "  - name: BMW\n" +
+            "    models: [320, X3, X5]\n" +
+            "  - name: Fiat\n" +
+            "    models: [500, Panda]", "yml");
+
+        YamlLoader yamlLoader = new YamlLoader(new ObjectMapper(new YAMLFactory()).findAndRegisterModules(), new PathLexer());
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = YamlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+
+        yamlLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceModuleConfigGestaltConfigLexer() throws GestaltException {
 
         GestaltConfig config = new GestaltConfig();

--- a/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
+++ b/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
@@ -3,7 +3,9 @@ package org.github.gestalt.config.yaml;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
+import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.source.ConfigSourcePackage;
 import org.github.gestalt.config.source.MapConfigSource;
@@ -47,6 +49,10 @@ class YamlLoaderTest {
             "    models: [500, Panda]", "yml");
 
         YamlLoader yamlLoader = new YamlLoader();
+        GestaltConfig config = new GestaltConfig();
+        config.setSentenceLexer(new PathLexer());
+
+        yamlLoader.applyConfig(config);
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 
@@ -66,6 +72,101 @@ class YamlLoaderTest {
                                                  .get().getIndex(2).get().getValue().get());
         Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
                                      .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceModuleConfig() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("name: Steve\n" +
+            "age: 42\n" +
+            "cars: \n" +
+            "  - name: Ford\n" +
+            "    models: [Fiesta, Focus, Mustang]\n" +
+            "  - name: BMW\n" +
+            "    models: [320, X3, X5]\n" +
+            "  - name: Fiat\n" +
+            "    models: [500, Panda]", "yml");
+
+        YamlLoader yamlLoader = new YamlLoader();
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = YamlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+
+        yamlLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
+    void loadSourceModuleConfigGestaltConfigLexer() throws GestaltException {
+
+        GestaltConfig config = new GestaltConfig();
+
+        var objectMapper = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+        var lexer = new PathLexer();
+        var moduleConfig = YamlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            //.setLexer(lexer)
+            .build();
+
+        config.registerModuleConfig(moduleConfig);
+        config.setSentenceLexer(lexer);
+
+        YamlLoader yamlLoader = new YamlLoader();
+        yamlLoader.applyConfig(config);
+
+        StringConfigSource source = new StringConfigSource("name: Steve\n" +
+            "age: 42\n" +
+            "cars: \n" +
+            "  - name: Ford\n" +
+            "    models: [Fiesta, Focus, Mustang]\n" +
+            "  - name: BMW\n" +
+            "    models: [320, X3, X5]\n" +
+            "  - name: Fiat\n" +
+            "    models: [500, Panda]", "yml");
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
     }
 
     @Test
@@ -116,7 +217,7 @@ class YamlLoaderTest {
             "  - name: Fiat\n" +
             "    models: [500, Panda]", "yml");
 
-        YamlLoader yamlLoader = new YamlLoader(new ObjectMapper(new YAMLFactory()));
+        YamlLoader yamlLoader = new YamlLoader(new ObjectMapper(new YAMLFactory()), new PathLexer());
 
         GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
 

--- a/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlModuleConfigTest.java
+++ b/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlModuleConfigTest.java
@@ -1,0 +1,26 @@
+package org.github.gestalt.config.yaml;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.github.gestalt.config.lexer.PathLexer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+class YamlModuleConfigTest {
+
+    @Test
+    public void createModuleConfig() {
+        var objectMapper = new ObjectMapper(new YAMLFactory()).findAndRegisterModules();
+        var lexer = new PathLexer();
+        var builder = YamlModuleConfigBuilder.builder()
+            .setObjectMapper(objectMapper)
+            .setLexer(lexer);
+
+        var moduleConfig = builder.build();
+
+        Assertions.assertEquals(objectMapper, moduleConfig.getObjectMapper());
+        Assertions.assertEquals(lexer, moduleConfig.getLexer());
+        Assertions.assertEquals("yaml", moduleConfig.name());
+    }
+}


### PR DESCRIPTION
feat: pass the sentence lexer into the Gestalt Config, so it can be applied in all the loaders. Use the lexer to normalize the strings instead of all using a lowercase. https://github.com/gestalt-config/gestalt/issues/179
For most loaders add a new module configuration. Allows Env Vars among others to be more customizable. https://github.com/gestalt-config/gestalt/issues/151
Get the system properties from the system wrapper for easier debugging and testing.