### PR TITLE
Feat: lexer improvements

### DIFF
--- a/gestalt-cdi/src/main/java/org/github/gestalt/config/cdi/GestaltConfigInjectionBean.java
+++ b/gestalt-cdi/src/main/java/org/github/gestalt/config/cdi/GestaltConfigInjectionBean.java
@@ -74,11 +74,6 @@ public final class GestaltConfigInjectionBean<T> implements Bean<T>, Passivation
     }
 
     @Override
-    public boolean isNullable() {
-        return false;
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public T create(CreationalContext<T> context) {
         InjectionPoint ip = (InjectionPoint) bm.getInjectableReference(new MetadataInjectionPoint(), context);

--- a/gestalt-cdi/src/main/java/org/github/gestalt/config/cdi/GestaltConfigsInjectionBean.java
+++ b/gestalt-cdi/src/main/java/org/github/gestalt/config/cdi/GestaltConfigsInjectionBean.java
@@ -39,11 +39,6 @@ public final class GestaltConfigsInjectionBean<T> implements Bean<T> {
     }
 
     @Override
-    public boolean isNullable() {
-        return false;
-    }
-
-    @Override
     public T create(final CreationalContext<T> creationalContext) {
         String prefix = configClassWithPrefix.getPrefix();
         if (prefix.isBlank()) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
@@ -101,7 +101,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         this.metricsManager = metricsManager;
         this.validationManager = validationManager;
         this.defaultTags = defaultTags;
-        this.decoderContext = new DecoderContext(decoderService, this, secretConcealer);
+        this.decoderContext = new DecoderContext(decoderService, this, secretConcealer, sentenceLexer);
     }
 
     List<ValidationError> getLoadErrors() {
@@ -261,7 +261,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         ConfigPrefix[] prefix = klass.getAnnotationsByType(ConfigPrefix.class);
         for (ConfigPrefix configPrefix : prefix) {
             if (combinedPath.length() > 0) {
-                combinedPath.append(sentenceLexer.getDeliminator());
+                combinedPath.append(sentenceLexer.getNormalizedDeliminator());
             }
             combinedPath.append(configPrefix.prefix());
         }
@@ -394,7 +394,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
             if (tokens.hasErrors()) {
                 throw new GestaltException("Unable to parse path: " + combinedPath, tokens.getErrors());
             } else {
-                GResultOf<T> results = getAndDecodeConfig2(combinedPath, tokens.results(), klass, tags);
+                GResultOf<T> results = getAndDecodeConfig(combinedPath, tokens.results(), klass, tags);
 
                 getConfigMetrics(results);
 
@@ -487,7 +487,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         }
     }
 
-    private <T> GResultOf<T> getAndDecodeConfig2(String path, List<Token> tokens, TypeCapture<T> klass, Tags tags) {
+    private <T> GResultOf<T> getAndDecodeConfig(String path, List<Token> tokens, TypeCapture<T> klass, Tags tags) {
         GResultOf<ConfigNode> node = configNodeService.navigateToNode(path, tokens, tags);
 
         if (!node.hasErrors() || node.hasErrors(ValidationLevel.MISSING_VALUE)) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/builder/GestaltBuilder.java
@@ -71,7 +71,7 @@ public class GestaltBuilder {
     private GestaltConfig gestaltConfig = new GestaltConfig();
     private MetricsManager metricsManager;
     private ValidationManager validationManager;
-    private ConfigNodeService configNodeService = new ConfigNodeManager();
+    private ConfigNodeService configNodeService = new ConfigNodeManager(sentenceLexer);
     private List<ConfigSourcePackage> configSourcePackages = new ArrayList<>();
     private List<Decoder<?>> decoders = new ArrayList<>();
     private List<ConfigLoader> configLoaders = new ArrayList<>();
@@ -1092,6 +1092,8 @@ public class GestaltBuilder {
         configureValidators();
         configureConfigLoaders();
         configurePostProcessors();
+
+        configNodeService.setLexer(sentenceLexer);
 
         // create a new GestaltCoreReloadStrategy to listen for Gestalt Core Reloads.
         CoreReloadListenersContainer coreReloadListenersContainer = new CoreReloadListenersContainer();

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ArrayDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ArrayDecoder.java
@@ -83,7 +83,7 @@ public final class ArrayDecoder<T> implements Decoder<T[]> {
             var valueOptional = node.getIndex(i);
             if (valueOptional.isPresent()) {
                 ConfigNode currentNode = valueOptional.get();
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(decoderContext.getDefaultLexer(), path, i);
                 GResultOf<?> resultOf = decoderContext.getDecoderService()
                     .decodeNode(nextPath, tags, currentNode, TypeCapture.of(klass.getComponentType()), decoderContext);
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigDecimalDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigDecimalDecoder.java
@@ -43,7 +43,7 @@ public final class BigDecimalDecoder extends LeafDecoder<BigDecimal> {
                 results = GResultOf.result(bigDecimal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigIntegerDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/BigIntegerDecoder.java
@@ -43,7 +43,7 @@ public final class BigIntegerDecoder extends LeafDecoder<BigInteger> {
                 results = GResultOf.result(bigDecimal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ByteDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ByteDecoder.java
@@ -39,9 +39,9 @@ public final class ByteDecoder extends LeafDecoder<Byte> {
             results = GResultOf.result(value.getBytes(Charset.defaultCharset())[0]);
         } else if (value.length() > 1) {
             results = GResultOf.resultOf(value.getBytes(Charset.defaultCharset())[0],
-                new ValidationError.DecodingByteTooLong(path, node, decoderContext.getSecretConcealer()));
+                new ValidationError.DecodingByteTooLong(path, node, decoderContext));
         } else  {
-            results = GResultOf.errors(new ValidationError.DecodingEmptyByte(path, node, decoderContext.getSecretConcealer()));
+            results = GResultOf.errors(new ValidationError.DecodingEmptyByte(path, node, decoderContext));
         }
 
         return results;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/CharDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/CharDecoder.java
@@ -42,7 +42,7 @@ public final class CharDecoder extends LeafDecoder<Character> {
         }
 
         if (value.length() != 1) {
-            error.add(new ValidationError.DecodingCharWrongSize(path, node, decoderContext.getSecretConcealer()));
+            error.add(new ValidationError.DecodingCharWrongSize(path, node, decoderContext));
         }
 
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DateDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DateDecoder.java
@@ -76,7 +76,7 @@ public final class DateDecoder extends LeafDecoder<Date> {
             results = GResultOf.result(Date.from(instant));
         } catch (DateTimeParseException e) {
             results = GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
         }
         return results;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DecoderContext.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DecoderContext.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.Gestalt;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 
 import java.util.Objects;
@@ -13,13 +14,14 @@ import java.util.Objects;
 public class DecoderContext {
     private final DecoderService decoderService;
     private final Gestalt gestalt;
-
+    private final SentenceLexer defaultLexer;
     private final SecretConcealer secretConcealer;
 
-    public DecoderContext(DecoderService decoderService, Gestalt gestalt, SecretConcealer secretConcealer) {
+    public DecoderContext(DecoderService decoderService, Gestalt gestalt, SecretConcealer secretConcealer, SentenceLexer defaultLexer) {
         this.decoderService = decoderService;
         this.gestalt = gestalt;
         this.secretConcealer = secretConcealer;
+        this.defaultLexer = defaultLexer;
     }
 
     public DecoderService getDecoderService() {
@@ -34,6 +36,10 @@ public class DecoderContext {
         return secretConcealer;
     }
 
+    public SentenceLexer getDefaultLexer() {
+        return defaultLexer;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -45,11 +51,12 @@ public class DecoderContext {
         DecoderContext that = (DecoderContext) o;
         return Objects.equals(decoderService, that.decoderService) &&
             Objects.equals(gestalt, that.gestalt) &&
-            Objects.equals(secretConcealer, that.secretConcealer);
+            Objects.equals(secretConcealer, that.secretConcealer) &&
+            Objects.equals(defaultLexer, that.defaultLexer);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(decoderService, gestalt, secretConcealer);
+        return Objects.hash(decoderService, gestalt, secretConcealer, defaultLexer);
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DoubleDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DoubleDecoder.java
@@ -40,7 +40,7 @@ public final class DoubleDecoder extends LeafDecoder<Double> {
                 results = GResultOf.result(longVal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/DurationDecoder.java
@@ -42,14 +42,14 @@ public final class DurationDecoder extends LeafDecoder<Duration> {
                 results = GResultOf.result(Duration.ofMillis(longVal));
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                    new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
             }
         } else {
             try {
                 results = GResultOf.result(Duration.parse(value));
             } catch (Exception e) {
                 results = GResultOf.errors(
-                    new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                    new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
             }
         }
         return results;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FloatDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/FloatDecoder.java
@@ -40,7 +40,7 @@ public final class FloatDecoder extends LeafDecoder<Float> {
                 results = GResultOf.result(floatVal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/InstantDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/InstantDecoder.java
@@ -41,7 +41,7 @@ public final class InstantDecoder extends LeafDecoder<Instant> {
             results = GResultOf.result(instant);
         } catch (DateTimeParseException e) {
             results = GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
         }
         return results;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/IntegerDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/IntegerDecoder.java
@@ -40,7 +40,7 @@ public final class IntegerDecoder extends LeafDecoder<Integer> {
                 results = GResultOf.result(intVal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ListDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ListDecoder.java
@@ -72,7 +72,7 @@ public final class ListDecoder extends CollectionDecoder<List<?>> {
             var valueOptional = node.getIndex(i);
             if (valueOptional.isPresent()) {
                 ConfigNode currentNode = valueOptional.get();
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(decoderContext.getDefaultLexer(), path, i);
                 GResultOf<?> resultOf = decoderContext.getDecoderService()
                     .decodeNode(nextPath, tags, currentNode, klass.getFirstParameterType(), decoderContext);
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateDecoder.java
@@ -71,7 +71,7 @@ public final class LocalDateDecoder extends LeafDecoder<LocalDate> {
             results = GResultOf.result(LocalDate.parse(value, formatter));
         } catch (DateTimeParseException e) {
             results = GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
         }
         return results;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateTimeDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LocalDateTimeDecoder.java
@@ -71,7 +71,7 @@ public final class LocalDateTimeDecoder extends LeafDecoder<LocalDateTime> {
             results = GResultOf.result(LocalDateTime.parse(value, formatter));
         } catch (DateTimeParseException e) {
             results = GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
         }
         return results;
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LongDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/LongDecoder.java
@@ -40,7 +40,7 @@ public final class LongDecoder extends LeafDecoder<Long> {
                 results = GResultOf.result(longVal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationError;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.*;
 import org.github.gestalt.config.reflect.TypeCapture;
 import org.github.gestalt.config.tag.Tags;
@@ -171,6 +172,8 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
 
     private Stream<Map.Entry<String, ConfigNode>> convertMapToStream(String path, Map.Entry<String, ConfigNode> entry,
                                                                      DecoderContext decoderContext) {
+
+        SentenceLexer lexer = decoderContext.getDefaultLexer();
         // if the key or entry is null, return the current entry and let later code deal with the null value.
         if (path == null || entry.getValue() == null) {
             return Stream.of(entry);
@@ -179,7 +182,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
 
             return node.getMapNode().entrySet()
                 .stream()
-                .flatMap(it -> convertMapToStream(pathForKey(decoderContext.getDefaultLexer(), path, it.getKey()), it, decoderContext));
+                .flatMap(it -> convertMapToStream(pathForKey(lexer, path, it.getKey()), it, decoderContext));
 
         } else if (entry.getValue() instanceof ArrayNode) {
             ArrayNode node = (ArrayNode) entry.getValue();
@@ -189,7 +192,9 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
 
             for (int i = 0; i < nodes.size(); i++) {
                 stream = Stream
-                    .concat(stream, convertMapToStream(pathForIndex(path, i), Map.entry(forIndex(i), nodes.get(i)), decoderContext));
+                    .concat(stream, convertMapToStream(
+                        pathForIndex(lexer, path, i),
+                        Map.entry(forIndex(lexer, i), nodes.get(i)), decoderContext));
             }
 
             return stream;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.lang.System.Logger.Level.TRACE;
+import static org.github.gestalt.config.utils.PathUtil.*;
 
 /**
  * Decode a Map. Assumes that the key is a simple class that can be decoded from a single string. ie a Boolean, String, Int.
@@ -82,7 +83,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
 
                     String[] keyValuePair = entry.split("(?<!\\\\)=", 2);
                     if (keyValuePair.length != 2) {
-                        errors.add(new ValidationError.MapEntryInvalid(path, entry, node, decoderContext.getSecretConcealer()));
+                        errors.add(new ValidationError.MapEntryInvalid(path, entry, node, decoderContext));
                         continue;
                     }
 
@@ -123,7 +124,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
                 // if the value of the map is a primitive or a wrapper, flat map any entries that are map nodes.
                 // if the value is a class, then we want to decode the map nodes into an object
                 if (ClassUtils.isPrimitiveOrWrapper(valueType.getRawType())) {
-                    stream = stream.flatMap(it -> convertMapToStream(it.getKey(), it));
+                    stream = stream.flatMap(it -> convertMapToStream(it.getKey(), it, decoderContext));
                 }
 
                 Map<?, ?> map = stream.map(it -> {
@@ -133,7 +134,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
                         return null;
                     }
 
-                    String nextPath = PathUtil.pathForKey(path, key);
+                    String nextPath = pathForKey(decoderContext.getDefaultLexer(), path, key);
                     GResultOf<Object> keyValidate = decoderContext.getDecoderService()
                         .decodeNode(nextPath, tags, new LeafNode(key), (TypeCapture<Object>) keyType, decoderContext);
                     GResultOf<Object> valueValidate = decoderContext.getDecoderService()
@@ -166,14 +167,17 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
         return results;
     }
 
-    private Stream<Map.Entry<String, ConfigNode>> convertMapToStream(String path, Map.Entry<String, ConfigNode> entry) {
+    private Stream<Map.Entry<String, ConfigNode>> convertMapToStream(String path, Map.Entry<String, ConfigNode> entry, DecoderContext decoderContext) {
         // if the key or entry is null, return the current entry and let later code deal with the null value.
         if (path == null || entry.getValue() == null) {
             return Stream.of(entry);
         } else if (entry.getValue() instanceof MapNode) {
             MapNode node = (MapNode) entry.getValue();
 
-            return node.getMapNode().entrySet().stream().flatMap(it -> convertMapToStream(path + "." + it.getKey(), it));
+            return node.getMapNode().entrySet()
+                .stream()
+                .flatMap(it -> convertMapToStream(pathForKey(decoderContext.getDefaultLexer(), path, it.getKey()), it, decoderContext));
+
         } else if (entry.getValue() instanceof ArrayNode) {
             ArrayNode node = (ArrayNode) entry.getValue();
 
@@ -181,7 +185,8 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
             List<ConfigNode> nodes = node.getArray();
 
             for (int i = 0; i < nodes.size(); i++) {
-                stream = Stream.concat(stream, convertMapToStream(path + "[" + i + "]", Map.entry("[" + i + "]", nodes.get(i))));
+                stream = Stream
+                    .concat(stream, convertMapToStream(pathForIndex(path, i), Map.entry(forIndex(i), nodes.get(i)), decoderContext));
             }
 
             return stream;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
@@ -7,7 +7,6 @@ import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.ClassUtils;
 import org.github.gestalt.config.utils.GResultOf;
 import org.github.gestalt.config.utils.Pair;
-import org.github.gestalt.config.utils.PathUtil;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -87,7 +86,10 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
                         continue;
                     }
 
-                    mapResult.put(keyValuePair[0].trim(), new LeafNode(keyValuePair[1].trim()));
+
+                    var mapKey = keyValuePair[0].trim().replace("\\,", ",").replace("\\=", "=");
+                    var mapValue = keyValuePair[1].trim().replace("\\,", ",").replace("\\=", "=");
+                    mapResult.put(mapKey, new LeafNode(mapValue));
                 }
 
                 // if there are no errors try and decode the new map.
@@ -167,7 +169,8 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
         return results;
     }
 
-    private Stream<Map.Entry<String, ConfigNode>> convertMapToStream(String path, Map.Entry<String, ConfigNode> entry, DecoderContext decoderContext) {
+    private Stream<Map.Entry<String, ConfigNode>> convertMapToStream(String path, Map.Entry<String, ConfigNode> entry,
+                                                                     DecoderContext decoderContext) {
         // if the key or entry is null, return the current entry and let later code deal with the null value.
         if (path == null || entry.getValue() == null) {
             return Stream.of(entry);

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDecoder.java
@@ -42,12 +42,12 @@ public final class OptionalDecoder implements Decoder<Optional<?>> {
                 return GResultOf.resultOf(Optional.of(optionalValue.results()), optionalValue.getErrors());
             } else {
                 var errors = optionalValue.getErrorsNotLevel(ValidationLevel.MISSING_VALUE);
-                errors.add(new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext.getSecretConcealer()));
+                errors.add(new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext));
                 return GResultOf.resultOf(Optional.ofNullable(optionalValue.results()), errors);
             }
         } else {
             return GResultOf.resultOf(Optional.empty(),
-                new ValidationError.OptionalMissingValueDecoding(path, name(), decoderContext.getSecretConcealer()));
+                new ValidationError.OptionalMissingValueDecoding(path, name(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDoubleDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalDoubleDecoder.java
@@ -45,7 +45,7 @@ public final class OptionalDoubleDecoder implements Decoder<OptionalDouble> {
             }
         } else {
             return GResultOf.resultOf(OptionalDouble.empty(),
-                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext.getSecretConcealer()));
+                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalIntDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalIntDecoder.java
@@ -45,7 +45,7 @@ public final class OptionalIntDecoder implements Decoder<OptionalInt> {
             }
         } else {
             return GResultOf.resultOf(OptionalInt.empty(),
-                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext.getSecretConcealer()));
+                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalLongDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/OptionalLongDecoder.java
@@ -45,7 +45,7 @@ public final class OptionalLongDecoder implements Decoder<OptionalLong> {
             }
         } else {
             return GResultOf.resultOf(OptionalLong.empty(),
-                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext.getSecretConcealer()));
+                new ValidationError.OptionalMissingValueDecoding(path, node, name(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/RecordDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/RecordDecoder.java
@@ -8,7 +8,6 @@ import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.node.MapNode;
 import org.github.gestalt.config.reflect.TypeCapture;
-import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.GResultOf;
 import org.github.gestalt.config.utils.PathUtil;
@@ -51,7 +50,6 @@ public final class RecordDecoder implements Decoder<Object> {
         List<ValidationError> errors = new ArrayList<>();
         Class<?> klass = type.getRawType();
         DecoderService decoderService = decoderContext.getDecoderService();
-        SecretConcealer secretConcealer = decoderContext.getSecretConcealer();
 
         final RecComponent[] recordComponents = RecordUtils.recordComponents(klass, Comparator.comparing(RecComponent::index));
         final Object[] values = new Object[recordComponents.length];
@@ -66,7 +64,7 @@ public final class RecordDecoder implements Decoder<Object> {
                 name = configAnnotation.path();
             }
             Type fieldClass = rc.typeGeneric();
-            String nextPath = PathUtil.pathForKey(path, name);
+            String nextPath = PathUtil.pathForKey(decoderContext.getDefaultLexer(), path, name);
 
             GResultOf<ConfigNode> configNode = decoderService.getNextNode(nextPath, name, node);
             var typeCapture = TypeCapture.of(fieldClass);
@@ -90,7 +88,7 @@ public final class RecordDecoder implements Decoder<Object> {
                     errors.addAll(defaultGResultOf.getErrors());
                     if (defaultGResultOf.hasResults()) {
                         foundValue = true;
-                        errors.add(new OptionalMissingValueDecoding(nextPath, node, name(), klass.getSimpleName(), secretConcealer));
+                        errors.add(new OptionalMissingValueDecoding(nextPath, node, name(), klass.getSimpleName(), decoderContext));
                         values[i] = defaultGResultOf.results();
                     }
                 } else {
@@ -101,7 +99,7 @@ public final class RecordDecoder implements Decoder<Object> {
                     if (decodedResults.hasResults()) {
                         //only add the errors if we actually found a result, otherwise we dont care.
                         errors.addAll(decodedResults.getErrorsNotLevel(ValidationLevel.MISSING_OPTIONAL_VALUE));
-                        errors.add(new OptionalMissingValueDecoding(nextPath, node, name(), klass.getSimpleName(), secretConcealer));
+                        errors.add(new OptionalMissingValueDecoding(nextPath, node, name(), klass.getSimpleName(), decoderContext));
                         foundValue = true;
                         values[i] = decodedResults.results();
                     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/SetDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/SetDecoder.java
@@ -63,7 +63,7 @@ public final class SetDecoder extends CollectionDecoder<Set<?>> {
             var valueOptional = node.getIndex(i);
             if (valueOptional.isPresent()) {
                 ConfigNode currentNode = valueOptional.get();
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(decoderContext.getDefaultLexer(), path, i);
                 GResultOf<?> resultOf = decoderContext.getDecoderService()
                     .decodeNode(nextPath, tags, currentNode, klass.getFirstParameterType(), decoderContext);
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ShortDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ShortDecoder.java
@@ -40,7 +40,7 @@ public final class ShortDecoder extends LeafDecoder<Short> {
                 results = GResultOf.result(intVal);
             } catch (NumberFormatException e) {
                 results = GResultOf.errors(
-                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.getSecretConcealer()));
+                    new ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext));
             }
         } else {
             results = GResultOf.errors(new ValidationError.DecodingNumberParsing(path, node, name()));

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/URIDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/URIDecoder.java
@@ -38,8 +38,7 @@ public final class URIDecoder extends LeafDecoder<URI> {
             return GResultOf.result(new URI(value));
         } catch (URISyntaxException e) {
             return GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getLocalizedMessage(),
-                    decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getLocalizedMessage(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/URLDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/URLDecoder.java
@@ -38,8 +38,7 @@ public final class URLDecoder extends LeafDecoder<URL> {
             return GResultOf.result(new URL(value));
         } catch (MalformedURLException e) {
             return GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getLocalizedMessage(),
-                    decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getLocalizedMessage(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/UUIDDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/UUIDDecoder.java
@@ -38,7 +38,7 @@ public final class UUIDDecoder extends LeafDecoder<UUID> {
             return GResultOf.result(UUID.fromString(value));
         } catch (IllegalArgumentException e) {
             return GResultOf.errors(
-                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext.getSecretConcealer()));
+                new ValidationError.ErrorDecodingException(path, node, name(), e.getMessage(), decoderContext));
         }
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/entity/ValidationError.java
@@ -1,5 +1,7 @@
 package org.github.gestalt.config.entity;
 
+import org.github.gestalt.config.decoder.DecoderContext;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.post.process.transform.substitution.SubstitutionNode;
 import org.github.gestalt.config.reflect.TypeCapture;
@@ -402,25 +404,25 @@ public abstract class ValidationError {
         private final ConfigNode node;
         private final String decoder;
         private final String className;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public OptionalMissingValueDecoding(String path, String decoder, SecretConcealer secretConcealer) {
-            this(path, null, decoder, null, secretConcealer);
+        public OptionalMissingValueDecoding(String path, String decoder, DecoderContext context) {
+            this(path, null, decoder, null, context);
         }
 
 
-        public OptionalMissingValueDecoding(String path, ConfigNode node, String decoder, SecretConcealer secretConcealer) {
-            this(path, node, decoder, null, secretConcealer);
+        public OptionalMissingValueDecoding(String path, ConfigNode node, String decoder, DecoderContext context) {
+            this(path, node, decoder, null, context);
         }
 
         public OptionalMissingValueDecoding(String path, ConfigNode node, String decoder, String className,
-                                            SecretConcealer secretConcealer) {
+                                            DecoderContext context) {
             super(ValidationLevel.MISSING_OPTIONAL_VALUE);
             this.path = path;
             this.node = node;
             this.decoder = decoder;
             this.className = className;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
@@ -428,7 +430,7 @@ public abstract class ValidationError {
             StringBuilder description = new StringBuilder(62);
             description.append("Missing Optional Value while decoding ").append(decoder).append(" on path: ").append(path);
             if (node != null) {
-                description.append(", with node: ").append(node.printer(path, secretConcealer));
+                description.append(", with node: ").append(node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()));
             }
             if (className != null) {
                 description.append(", with class: ").append(className);
@@ -615,20 +617,20 @@ public abstract class ValidationError {
         private final String path;
         private final ConfigNode node;
         private final String nodeType;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public DecodingNumberFormatException(String path, ConfigNode node, String nodeType, SecretConcealer secretConcealer) {
+        public DecodingNumberFormatException(String path, ConfigNode node, String nodeType, DecoderContext context) {
             super(ValidationLevel.ERROR);
             this.path = path;
             this.node = node;
             this.nodeType = nodeType;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
-            return "Unable to decode a number on path: " + path + ", from node: " + node.printer(path, secretConcealer) +
-                " attempting to decode " + nodeType;
+            return "Unable to decode a number on path: " + path + ", from node: " +
+                node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()) + " attempting to decode " + nodeType;
         }
     }
 
@@ -638,19 +640,19 @@ public abstract class ValidationError {
     public static class DecodingCharWrongSize extends ValidationError {
         private final String path;
         private final ConfigNode node;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public DecodingCharWrongSize(String path, ConfigNode node, SecretConcealer secretConcealer) {
+        public DecodingCharWrongSize(String path, ConfigNode node, DecoderContext context) {
             super(ValidationLevel.WARN);
             this.path = path;
             this.node = node;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
-            return "Expected a char on path: " + path + ", decoding node: " + node.printer(path, secretConcealer) +
-                " received the wrong size";
+            return "Expected a char on path: " + path + ", decoding node: " +
+                node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()) + " received the wrong size";
         }
     }
 
@@ -660,19 +662,19 @@ public abstract class ValidationError {
     public static class DecodingByteTooLong extends ValidationError {
         private final String path;
         private final ConfigNode node;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public DecodingByteTooLong(String path, ConfigNode node, SecretConcealer secretConcealer) {
+        public DecodingByteTooLong(String path, ConfigNode node, DecoderContext context) {
             super(ValidationLevel.WARN);
             this.path = path;
             this.node = node;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
-            return "Expected a Byte on path: " + path + ", decoding node: " + node.printer(path, secretConcealer) +
-                " received the wrong size";
+            return "Expected a Byte on path: " + path + ", decoding node: " +
+                node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()) + " received the wrong size";
         }
     }
 
@@ -682,19 +684,19 @@ public abstract class ValidationError {
     public static class DecodingEmptyByte extends ValidationError {
         private final String path;
         private final ConfigNode node;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public DecodingEmptyByte(String path, ConfigNode node, SecretConcealer secretConcealer) {
+        public DecodingEmptyByte(String path, ConfigNode node, DecoderContext context) {
             super(ValidationLevel.ERROR);
             this.path = path;
             this.node = node;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
-            return "Expected a Byte on path: " + path + ", decoding node: " + node.printer(path, secretConcealer) +
-                " received an empty node";
+            return "Expected a Byte on path: " + path + ", decoding node: " +
+                node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()) + " received an empty node";
         }
     }
 
@@ -706,21 +708,21 @@ public abstract class ValidationError {
         private final ConfigNode node;
         private final String decoder;
         private final String reason;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public ErrorDecodingException(String path, ConfigNode node, String decoder, String reason, SecretConcealer secretConcealer) {
+        public ErrorDecodingException(String path, ConfigNode node, String decoder, String reason, DecoderContext context) {
             super(ValidationLevel.ERROR);
             this.path = path;
             this.node = node;
             this.decoder = decoder;
             this.reason = reason;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
-            return "Unable to decode a " + decoder + " on path: " + path + ", from node: " + node.printer(path, secretConcealer) +
-                ", with reason: " + reason;
+            return "Unable to decode a " + decoder + " on path: " + path + ", from node: " +
+                node.printer(path, context.getSecretConcealer(), context.getDefaultLexer()) + ", with reason: " + reason;
         }
     }
 
@@ -765,21 +767,21 @@ public abstract class ValidationError {
         private final String path;
         private final String content;
         private final ConfigNode node;
-        private final SecretConcealer secretConcealer;
+        private final DecoderContext context;
 
-        public MapEntryInvalid(String path, String content, ConfigNode node, SecretConcealer secretConcealer) {
+        public MapEntryInvalid(String path, String content, ConfigNode node, DecoderContext context) {
             super(ValidationLevel.ERROR);
 
             this.path = path;
             this.content = content;
             this.node = node;
-            this.secretConcealer = secretConcealer;
+            this.context = context;
         }
 
         @Override
         public String description() {
             return "Map entry is not in the format '<KEY>=<VALUE> for entry" + content + ", on path " + path +
-                ", for node: " + node.printer(path, secretConcealer);
+                ", for node: " + node.printer(path, context.getSecretConcealer(), context.getDefaultLexer());
         }
     }
 
@@ -1340,19 +1342,22 @@ public abstract class ValidationError {
         private final ConfigNode node;
         private final int depth;
         private final SecretConcealer secretConcealer;
+        private final SentenceLexer lexer;
 
-        public ExceededMaximumNestedSubstitutionDepth(String path, int depth, ConfigNode node, SecretConcealer secretConcealer) {
+        public ExceededMaximumNestedSubstitutionDepth(String path, int depth, ConfigNode node, SecretConcealer secretConcealer,
+                                                      SentenceLexer lexer) {
             super(ValidationLevel.ERROR);
             this.path = path;
             this.node = node;
             this.depth = depth;
             this.secretConcealer = secretConcealer;
+            this.lexer = lexer;
         }
 
         @Override
         public String description() {
             return "Exceeded maximum nested substitution depth of " + depth + " on path " + path + " for node: " +
-                node.printer(path, secretConcealer);
+                node.printer(path, secretConcealer, lexer);
         }
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
@@ -69,11 +69,11 @@ public final class PathLexer extends SentenceLexer {
     /**
      * construct a Path lexer, remember that the delimiter is a regex, so if you want to use . you need to escape it. "."
      *
-     * @param delimiter        the character to split the sentence
-     * @param pathPatternRegex a regex with capture groups to decide what kind of token this is. The regex should have a capture group
-     *                         name = name of the element
-     *                         array = if this element is an array
-     *                         index = the index for the array
+     * @param delimiter          the character to split the sentence
+     * @param pathPatternRegex   a regex with capture groups to decide what kind of token this is. The regex should have a capture group
+     *                           name = name of the element
+     *                           array = if this element is an array
+     *                           index = the index for the array
      * @param sentenceNormalizer defines how to normalize a sentence.
      */
     public PathLexer(String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
@@ -84,12 +84,12 @@ public final class PathLexer extends SentenceLexer {
      * construct a Path lexer, remember that the delimiter is a regex, so if you want to use . you need to escape it. "."
      *
      * @param normalizedDelimiter how we want to represent the path when we rebuild it from the config tree.
-     * @param delimiter        the character to split the sentence
-     * @param pathPatternRegex a regex with capture groups to decide what kind of token this is. The regex should have a capture group
-     *                         name = name of the element
-     *                         array = if this element is an array
-     *                         index = the index for the array
-     * @param sentenceNormalizer defines how to normalize a sentence.
+     * @param delimiter           the character to split the sentence
+     * @param pathPatternRegex    a regex with capture groups to decide what kind of token this is. The regex should have a capture group
+     *                            name = name of the element
+     *                            array = if this element is an array
+     *                            index = the index for the array
+     * @param sentenceNormalizer  defines how to normalize a sentence.
      */
     public PathLexer(String normalizedDelimiter, String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
         this(normalizedDelimiter, delimiter, pathPatternRegex, sentenceNormalizer, "[", "]", "=");
@@ -100,7 +100,11 @@ public final class PathLexer extends SentenceLexer {
         this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
         this.normalizedDelimiter = normalizedDelimiter;
         this.delimiter = delimiter;
-        this.delimiterRegex = Pattern.quote(delimiter);
+        if (delimiter.length() == 1) {
+            this.delimiterRegex = Pattern.quote(delimiter);
+        } else {
+            this.delimiterRegex = delimiter;
+        }
         this.sentenceNormalizer = sentenceNormalizer;
         this.normalizedArrayOpenTag = normalizedArrayOpenTag;
         this.normalizedArrayCloseTag = normalizedArrayCloseTag;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
@@ -30,6 +30,9 @@ public final class PathLexer extends SentenceLexer {
     public static final String DELIMITER_DEFAULT = ".";
     private final Pattern pathPattern;
     private final String normalizedDelimiter;
+    private final String normalizedArrayOpenTag;
+    private final String normalizedArrayCloseTag;
+    private final String normalizedMapTag;
     private final String delimiter;
     private final String delimiterRegex;
     private final SentenceNormalizer sentenceNormalizer;
@@ -38,11 +41,7 @@ public final class PathLexer extends SentenceLexer {
      * Build a path lexer to tokenize a path.
      */
     public PathLexer() {
-        this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
-        this.normalizedDelimiter = DELIMITER_DEFAULT;
-        this.delimiter = DELIMITER_DEFAULT;
-        this.delimiterRegex = Pattern.quote(DELIMITER_DEFAULT);
-        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
+        this(DELIMITER_DEFAULT, DELIMITER_DEFAULT, DEFAULT_EVALUATOR, new LowerCaseSentenceNormalizer(), "[", "]", "=");
     }
 
     /**
@@ -51,11 +50,7 @@ public final class PathLexer extends SentenceLexer {
      * @param delimiter the character to split the sentence
      */
     public PathLexer(String delimiter) {
-        this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
-        this.normalizedDelimiter = delimiter;
-        this.delimiter = delimiter;
-        this.delimiterRegex = Pattern.quote(delimiter);
-        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
+        this(delimiter, delimiter, DEFAULT_EVALUATOR, new LowerCaseSentenceNormalizer(), "[", "]", "=");
     }
 
     /**
@@ -68,11 +63,7 @@ public final class PathLexer extends SentenceLexer {
      *                         index = the index for the array
      */
     public PathLexer(String delimiter, String pathPatternRegex) {
-        this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
-        this.normalizedDelimiter = delimiter;
-        this.delimiter = delimiter;
-        this.delimiterRegex = Pattern.quote(delimiter);
-        this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
+        this(delimiter, delimiter, pathPatternRegex, new LowerCaseSentenceNormalizer(), "[", "]", "=");
     }
 
     /**
@@ -86,11 +77,7 @@ public final class PathLexer extends SentenceLexer {
      * @param sentenceNormalizer defines how to normalize a sentence.
      */
     public PathLexer(String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
-        this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
-        this.normalizedDelimiter = delimiter;
-        this.delimiter = delimiter;
-        this.delimiterRegex = Pattern.quote(delimiter);
-        this.sentenceNormalizer = sentenceNormalizer;
+        this(delimiter, delimiter, pathPatternRegex, sentenceNormalizer, "[", "]", "=");
     }
 
     /**
@@ -105,16 +92,39 @@ public final class PathLexer extends SentenceLexer {
      * @param sentenceNormalizer defines how to normalize a sentence.
      */
     public PathLexer(String normalizedDelimiter, String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
+        this(normalizedDelimiter, delimiter, pathPatternRegex, sentenceNormalizer, "[", "]", "=");
+    }
+
+    public PathLexer(String normalizedDelimiter, String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer,
+                     String normalizedArrayOpenTag, String normalizedArrayCloseTag, String normalizedMapTag) {
         this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
         this.normalizedDelimiter = normalizedDelimiter;
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
         this.sentenceNormalizer = sentenceNormalizer;
+        this.normalizedArrayOpenTag = normalizedArrayOpenTag;
+        this.normalizedArrayCloseTag = normalizedArrayCloseTag;
+        this.normalizedMapTag = normalizedMapTag;
     }
 
     @Override
     public String getNormalizedDeliminator() {
         return normalizedDelimiter;
+    }
+
+    @Override
+    public String getNormalizedArrayOpenTag() {
+        return normalizedArrayOpenTag;
+    }
+
+    @Override
+    public String getNormalizedArrayCloseTag() {
+        return normalizedArrayCloseTag;
+    }
+
+    @Override
+    public String getNormalizedMapTag() {
+        return normalizedMapTag;
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
@@ -29,6 +29,7 @@ public final class PathLexer extends SentenceLexer {
     public static final String DEFAULT_EVALUATOR = "^((?<name>[\\w .,+=\\-;:\"'`~!@#$%^&*()\\<>]+)(?<array>\\[(?<index>\\d*)])?)$";
     public static final String DELIMITER_DEFAULT = ".";
     private final Pattern pathPattern;
+    private final String normalizedDelimiter;
     private final String delimiter;
     private final String delimiterRegex;
     private final SentenceNormalizer sentenceNormalizer;
@@ -38,6 +39,7 @@ public final class PathLexer extends SentenceLexer {
      */
     public PathLexer() {
         this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
+        this.normalizedDelimiter = DELIMITER_DEFAULT;
         this.delimiter = DELIMITER_DEFAULT;
         this.delimiterRegex = Pattern.quote(DELIMITER_DEFAULT);
         this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
@@ -50,6 +52,7 @@ public final class PathLexer extends SentenceLexer {
      */
     public PathLexer(String delimiter) {
         this.pathPattern = Pattern.compile(DEFAULT_EVALUATOR, Pattern.CASE_INSENSITIVE);
+        this.normalizedDelimiter = delimiter;
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
         this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
@@ -66,6 +69,7 @@ public final class PathLexer extends SentenceLexer {
      */
     public PathLexer(String delimiter, String pathPatternRegex) {
         this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
+        this.normalizedDelimiter = delimiter;
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
         this.sentenceNormalizer = new LowerCaseSentenceNormalizer();
@@ -83,9 +87,34 @@ public final class PathLexer extends SentenceLexer {
      */
     public PathLexer(String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
         this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
+        this.normalizedDelimiter = delimiter;
         this.delimiter = delimiter;
         this.delimiterRegex = Pattern.quote(delimiter);
         this.sentenceNormalizer = sentenceNormalizer;
+    }
+
+    /**
+     * construct a Path lexer, remember that the delimiter is a regex, so if you want to use . you need to escape it. "."
+     *
+     * @param normalizedDelimiter how we want to represent the path when we rebuild it from the config tree.
+     * @param delimiter        the character to split the sentence
+     * @param pathPatternRegex a regex with capture groups to decide what kind of token this is. The regex should have a capture group
+     *                         name = name of the element
+     *                         array = if this element is an array
+     *                         index = the index for the array
+     * @param sentenceNormalizer defines how to normalize a sentence.
+     */
+    public PathLexer(String normalizedDelimiter, String delimiter, String pathPatternRegex, SentenceNormalizer sentenceNormalizer) {
+        this.pathPattern = Pattern.compile(pathPatternRegex, Pattern.CASE_INSENSITIVE);
+        this.normalizedDelimiter = normalizedDelimiter;
+        this.delimiter = delimiter;
+        this.delimiterRegex = Pattern.quote(delimiter);
+        this.sentenceNormalizer = sentenceNormalizer;
+    }
+
+    @Override
+    public String getNormalizedDeliminator() {
+        return normalizedDelimiter;
     }
 
     @Override

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexer.java
@@ -137,7 +137,7 @@ public final class PathLexer extends SentenceLexer {
     }
 
     @Override
-    protected List<String> tokenizer(String sentence) {
+    public List<String> tokenizer(String sentence) {
         return sentence != null && !sentence.isEmpty() ? List.of(sentence.split(delimiterRegex)) : Collections.emptyList();
     }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
@@ -10,7 +10,7 @@ public final class PathLexerBuilder {
     private String normalizedArrayOpenTag = "[";
     private String normalizedArrayCloseTag = "]";
     private String normalizedMapTag = "=";
-    private String delimiter= ".";
+    private String delimiter = ".";
     private SentenceNormalizer sentenceNormalizer = new LowerCaseSentenceNormalizer();
     private String pathPatternRegex = PathLexer.DEFAULT_EVALUATOR;
 
@@ -90,9 +90,9 @@ public final class PathLexerBuilder {
 
     /**
      * a regex with capture groups to decide what kind of token this is. The regex should have a capture group.
-     *                          name = name of the element
-     *                          array = if this element is an array
-     *                          index = the index for the array
+     * name = name of the element
+     * array = if this element is an array
+     * index = the index for the array
      *
      * @param pathPatternRegex path regex
      * @return the builder

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
@@ -1,0 +1,114 @@
+package org.github.gestalt.config.lexer;
+
+/**
+ * Builder for the path lexer.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public final class PathLexerBuilder {
+    private String normalizedDelimiter;
+    private String normalizedArrayOpenTag;
+    private String normalizedArrayCloseTag;
+    private String normalizedMapTag;
+    private String delimiter;
+    private SentenceNormalizer sentenceNormalizer;
+    private String pathPatternRegex;
+
+    private PathLexerBuilder() {
+    }
+
+    public static PathLexerBuilder builder() {
+        return new PathLexerBuilder();
+    }
+
+    /**
+     * the deliminator that we use to represent a normalized path.
+     * Ie how we want to display a path being rebuilt from the config tree.
+     *
+     * @param normalizedDelimiter deliminator that we use to represent a normalized path.
+     * @return the builder
+     */
+    public PathLexerBuilder setNormalizedDelimiter(String normalizedDelimiter) {
+        this.normalizedDelimiter = normalizedDelimiter;
+        return this;
+    }
+
+    /**
+     * the deliminator that we use to represent a normalized opening tag for an array.
+     *
+     * @param normalizedArrayOpenTag the deliminator that we use to represent a normalized opening tag for an array.
+     * @return the builder
+     */
+    public PathLexerBuilder setNormalizedArrayOpenTag(String normalizedArrayOpenTag) {
+        this.normalizedArrayOpenTag = normalizedArrayOpenTag;
+        return this;
+    }
+
+    /**
+     * the deliminator that we use to represent a normalized closing tag for an array.
+     *
+     * @param normalizedArrayCloseTag the deliminator that we use to represent a normalized closing tag for an array.
+     * @return the builder
+     */
+    public PathLexerBuilder setNormalizedArrayCloseTag(String normalizedArrayCloseTag) {
+        this.normalizedArrayCloseTag = normalizedArrayCloseTag;
+        return this;
+    }
+
+    /**
+     * Return the deliminator that we use to represent a normalized map separator.
+     *
+     * @param normalizedMapTag Return the deliminator that we use to represent a normalized map separator.
+     * @return the builder
+     */
+    public PathLexerBuilder setNormalizedMapTag(String normalizedMapTag) {
+        this.normalizedMapTag = normalizedMapTag;
+        return this;
+    }
+
+    /**
+     * the character to split the sentence.
+     *
+     * @param delimiter the character to split the sentence
+     * @return the builder
+     */
+    public PathLexerBuilder setDelimiter(String delimiter) {
+        this.delimiter = delimiter;
+        return this;
+    }
+
+    /**
+     * defines how to normalize a sentence.
+     *
+     * @param sentenceNormalizer defines how to normalize a sentence.
+     * @return the builder
+     */
+    public PathLexerBuilder setSentenceNormalizer(SentenceNormalizer sentenceNormalizer) {
+        this.sentenceNormalizer = sentenceNormalizer;
+        return this;
+    }
+
+    /**
+     * a regex with capture groups to decide what kind of token this is. The regex should have a capture group.
+     *                          name = name of the element
+     *                          array = if this element is an array
+     *                          index = the index for the array
+     *                          
+     * @param pathPatternRegex path regex
+     * @return the builder
+     */
+    public PathLexerBuilder setPathPatternRegex(String pathPatternRegex) {
+        this.pathPatternRegex = pathPatternRegex;
+        return this;
+    }
+
+    /**
+     * build the path lexer.
+     *
+     * @return the path lexer
+     */
+    public PathLexer build() {
+        return new PathLexer(normalizedDelimiter, delimiter, pathPatternRegex, sentenceNormalizer,
+            normalizedArrayOpenTag, normalizedArrayCloseTag, normalizedMapTag);
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/PathLexerBuilder.java
@@ -6,13 +6,13 @@ package org.github.gestalt.config.lexer;
  * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
  */
 public final class PathLexerBuilder {
-    private String normalizedDelimiter;
-    private String normalizedArrayOpenTag;
-    private String normalizedArrayCloseTag;
-    private String normalizedMapTag;
-    private String delimiter;
-    private SentenceNormalizer sentenceNormalizer;
-    private String pathPatternRegex;
+    private String normalizedDelimiter = ".";
+    private String normalizedArrayOpenTag = "[";
+    private String normalizedArrayCloseTag = "]";
+    private String normalizedMapTag = "=";
+    private String delimiter= ".";
+    private SentenceNormalizer sentenceNormalizer = new LowerCaseSentenceNormalizer();
+    private String pathPatternRegex = PathLexer.DEFAULT_EVALUATOR;
 
     private PathLexerBuilder() {
     }
@@ -93,7 +93,7 @@ public final class PathLexerBuilder {
      *                          name = name of the element
      *                          array = if this element is an array
      *                          index = the index for the array
-     *                          
+     *
      * @param pathPatternRegex path regex
      * @return the builder
      */

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
@@ -16,7 +16,15 @@ import java.util.stream.Collectors;
 public abstract class SentenceLexer {
 
     /**
-     * Return the deliminator.
+     * Return the deliminator that we use to represent a normalized path.
+     * Ie how we want to display a path being rebuilt from the config tree
+     *
+     * @return the deliminator
+     */
+    public abstract String getNormalizedDeliminator();
+
+    /**
+     * Return the deliminator that we use split apart a path. Ie what we turn all configurations into.
      *
      * @return the deliminator
      */

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
@@ -24,6 +24,27 @@ public abstract class SentenceLexer {
     public abstract String getNormalizedDeliminator();
 
     /**
+     *  Return the deliminator that we use to represent a normalized opening tag for an array.
+     *
+     * @return the deliminator that we use to represent a normalized opening tag for an array
+     */
+    public abstract String getNormalizedArrayOpenTag();
+
+    /**
+     *  Return the deliminator that we use to represent a normalized closing tag for an array.
+     *
+     * @return the deliminator that we use to represent a normalized closing tag for an array
+     */
+    public abstract String getNormalizedArrayCloseTag();
+
+    /**
+     *  Return the deliminator that we use to represent a normalized map separator.
+     *
+     * @return the deliminator that we use to represent a normalized map separator
+     */
+    public abstract String getNormalizedMapTag();
+
+    /**
      * Return the deliminator that we use split apart a path. Ie what we turn all configurations into.
      *
      * @return the deliminator

--- a/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/lexer/SentenceLexer.java
@@ -57,7 +57,7 @@ public abstract class SentenceLexer {
      * @param sentence the sentence to tokenize
      * @return list of tokenized strings from sentance.
      */
-    protected abstract List<String> tokenizer(String sentence);
+    public abstract List<String> tokenizer(String sentence);
 
     /**
      * Takes in an elements such as abc or def[3] then converts it into a Token.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/ConfigCompiler.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/ConfigCompiler.java
@@ -74,7 +74,7 @@ public final class ConfigCompiler {
                 new Pair<>(validatedToken.getFirst().results(), new ConfigValue(validatedToken.getSecond())))
             .collect(Collectors.toList());
 
-        GResultOf<ConfigNode> parserResults = parser.parse(validTokens, failOnErrors);
+        GResultOf<ConfigNode> parserResults = parser.parse(lexer, validTokens, failOnErrors);
         errorMessage.addAll(parserResults.getErrors());
         return GResultOf.resultOf(parserResults.results(), errorMessage);
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/ArrayNode.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/ArrayNode.java
@@ -1,5 +1,7 @@
 package org.github.gestalt.config.node;
 
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.github.gestalt.config.utils.PathUtil;
 
@@ -85,15 +87,16 @@ public final class ArrayNode implements ConfigNode {
 
     @Override
     public String toString() {
-        return printer("", null);
+        // should not be used.
+        return printer("", null, new PathLexer());
     }
 
     @Override
-    public String printer(String path, SecretConcealer secretConcealer) {
+    public String printer(String path, SecretConcealer secretConcealer, SentenceLexer lexer) {
         return "ArrayNode{" +
             "values=[" +
             IntStream.range(0, values.size())
-                .mapToObj(n -> values.get(n).printer(PathUtil.pathForIndex(path, n), secretConcealer))
+                .mapToObj(n -> values.get(n).printer(PathUtil.pathForIndex(path, n), secretConcealer, lexer))
                 .collect(Collectors.joining(", ")) +
             "]}";
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/ArrayNode.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/ArrayNode.java
@@ -96,7 +96,7 @@ public final class ArrayNode implements ConfigNode {
         return "ArrayNode{" +
             "values=[" +
             IntStream.range(0, values.size())
-                .mapToObj(n -> values.get(n).printer(PathUtil.pathForIndex(path, n), secretConcealer, lexer))
+                .mapToObj(n -> values.get(n).printer(PathUtil.pathForIndex(lexer, path, n), secretConcealer, lexer))
                 .collect(Collectors.joining(", ")) +
             "]}";
     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNode.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNode.java
@@ -1,5 +1,6 @@
 package org.github.gestalt.config.node;
 
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 
 import java.util.Optional;
@@ -48,5 +49,14 @@ public interface ConfigNode {
      */
     int size();
 
-    String printer(String path, SecretConcealer secretConcealer);
+    /**
+     * Safely prints out the config tree at this path.
+     *
+     * @param path the current path.
+     * @param secretConcealer used to conceal any secrets.
+     * @param lexer lexer used to get the normalized path delimiters.
+     *
+     * @return the safe string with secrets concealed.
+     */
+    String printer(String path, SecretConcealer secretConcealer, SentenceLexer lexer);
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNodeManager.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNodeManager.java
@@ -152,7 +152,7 @@ public final class ConfigNodeManager implements ConfigNodeService {
         for (int i = 0; i < size; i++) {
             Optional<ConfigNode> currentNodeOption = node.getIndex(i);
             if (currentNodeOption.isPresent()) {
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(lexer, path, i);
                 GResultOf<ConfigNode> newNode = postProcess(nextPath, currentNodeOption.get(), postProcessors);
 
                 errors.addAll(newNode.getErrors());
@@ -258,7 +258,7 @@ public final class ConfigNodeManager implements ConfigNodeService {
             if (valueOptional.isEmpty()) {
                 errors.add(new ValidationError.ArrayMissingIndex(i, path));
             } else {
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(lexer, path, i);
                 errors.addAll(validateNode(nextPath, valueOptional.get()));
             }
         }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNodeService.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/ConfigNodeService.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.node;
 
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.post.process.PostProcessor;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.github.gestalt.config.tag.Tags;
@@ -17,6 +18,12 @@ import java.util.List;
  */
 public interface ConfigNodeService {
 
+    /**
+     * Set the sentence lexer used to rebuild normalized paths.
+     *
+     * @param lexer the sentence lexer used to rebuild normalized paths.
+     */
+    void setLexer(SentenceLexer lexer);
     /**
      * Add a new node, if a root already exists merge the nodes.
      * When adding a node and merging, the new node always takes precedence.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/LeafNode.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/LeafNode.java
@@ -1,5 +1,7 @@
 package org.github.gestalt.config.node;
 
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 
 import java.util.Objects;
@@ -66,11 +68,12 @@ public final class LeafNode implements ConfigNode {
 
     @Override
     public String toString() {
-        return printer("", null);
+        // should not be used.
+        return printer("", null, new PathLexer());
     }
 
     @Override
-    public String printer(String path, SecretConcealer secretConcealer) {
+    public String printer(String path, SecretConcealer secretConcealer, SentenceLexer lexer) {
         String nodeValue = value;
         if (secretConcealer != null) {
             nodeValue = secretConcealer.concealSecret(path, nodeValue);

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/MapNode.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/MapNode.java
@@ -1,5 +1,7 @@
 package org.github.gestalt.config.node;
 
+import org.github.gestalt.config.lexer.PathLexer;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.github.gestalt.config.utils.PathUtil;
 
@@ -84,17 +86,18 @@ public final class MapNode implements ConfigNode {
 
     @Override
     public String toString() {
-        return printer("", null);
+        // should not be used.
+        return printer("", null, new PathLexer());
     }
 
     @Override
-    public String printer(String path, SecretConcealer secretConcealer) {
+    public String printer(String path, SecretConcealer secretConcealer, SentenceLexer lexer) {
         return "MapNode{" +
             nodes.entrySet().stream()
                 .map((it) -> {
                     var printedNode = new StringBuilder().append(it.getKey()).append('=');
                     if (it.getValue() != null) {
-                        printedNode.append(it.getValue().printer(PathUtil.pathForKey(path, it.getKey()), secretConcealer));
+                        printedNode.append(it.getValue().printer(PathUtil.pathForKey(lexer, path, it.getKey()), secretConcealer, lexer));
                     } else {
                         printedNode.append("'null'");
                     }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/MergeNodes.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/MergeNodes.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.node;
 
 import org.github.gestalt.config.entity.ValidationError;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.utils.GResultOf;
 import org.github.gestalt.config.utils.PathUtil;
 
@@ -26,19 +27,20 @@ public final class MergeNodes {
      * Merge two nodes and return the results of the merge. The values in node1 will be overridden by the values in node2
      *
      * @param path  the path of the nodes we are merging.
+     * @param lexer lexer used to get the delimiter to build the path
      * @param node1 the base node, its properties will be overridden by the node2
      * @param node2 the node to override the values of.
      * @return the merged nodes.
      */
-    public static GResultOf<ConfigNode> mergeNodes(String path, ConfigNode node1, ConfigNode node2) {
+    public static GResultOf<ConfigNode> mergeNodes(String path, SentenceLexer lexer, ConfigNode node1, ConfigNode node2) {
         if (node1.getClass() != node2.getClass()) {
             return GResultOf.errors(
                 new ValidationError.UnableToMergeDifferentNodes(node1.getClass(), node2.getClass()));
         } else {
             if (node1 instanceof ArrayNode) {
-                return mergeArrayNodes(path, (ArrayNode) node1, (ArrayNode) node2);
+                return mergeArrayNodes(path, lexer, (ArrayNode) node1, (ArrayNode) node2);
             } else if (node1 instanceof MapNode) {
-                return mergeMapNodes(path, (MapNode) node1, (MapNode) node2);
+                return mergeMapNodes(path, lexer, (MapNode) node1, (MapNode) node2);
             } else if (node1 instanceof LeafNode) {
                 return mergeLeafNodes(path, (LeafNode) node1, (LeafNode) node2);
             } else {
@@ -47,7 +49,7 @@ public final class MergeNodes {
         }
     }
 
-    private static GResultOf<ConfigNode> mergeArrayNodes(String path, ArrayNode arrayNode1, ArrayNode arrayNode2) {
+    private static GResultOf<ConfigNode> mergeArrayNodes(String path, SentenceLexer lexer, ArrayNode arrayNode1, ArrayNode arrayNode2) {
         // get the maximum array size of both the nodes.
         int maxSize = Math.max(arrayNode1.size(), arrayNode2.size());
         ConfigNode[] values = new ConfigNode[maxSize];
@@ -62,7 +64,7 @@ public final class MergeNodes {
             Optional<ConfigNode> array2AtIndex = arrayNode2.getIndex(i);
             if (array1AtIndex.isPresent() && array2AtIndex.isPresent()) {
                 String nextPath = PathUtil.pathForIndex(path, i);
-                GResultOf<ConfigNode> result = mergeNodes(nextPath, array1AtIndex.get(), array2AtIndex.get());
+                GResultOf<ConfigNode> result = mergeNodes(nextPath, lexer, array1AtIndex.get(), array2AtIndex.get());
 
                 // if there are errors, add them to the error list abd do not add the merge results
                 errors.addAll(result.getErrors());
@@ -84,7 +86,7 @@ public final class MergeNodes {
         return resultOf(results, errors);
     }
 
-    private static GResultOf<ConfigNode> mergeMapNodes(String path, MapNode mapNode1, MapNode mapNode2) {
+    private static GResultOf<ConfigNode> mergeMapNodes(String path, SentenceLexer lexer, MapNode mapNode1, MapNode mapNode2) {
         Map<String, ConfigNode> mergedNode = new HashMap<>();
         List<ValidationError> errors = new ArrayList<>();
 
@@ -98,8 +100,8 @@ public final class MergeNodes {
             } else if (entry.getValue() == null) {
                 errors.add(new ValidationError.EmptyNodeValueProvided(path, key));
             } else if (mapNode2.getKey(key).isPresent()) {
-                String nextPath = PathUtil.pathForKey(path, key);
-                GResultOf<ConfigNode> result = mergeNodes(nextPath, entry.getValue(), mapNode2.getKey(key).get());
+                String nextPath = PathUtil.pathForKey(lexer, path, key);
+                GResultOf<ConfigNode> result = mergeNodes(nextPath, lexer, entry.getValue(), mapNode2.getKey(key).get());
 
                 // if there are errors, add them to the error list abd do not add the merge results
                 errors.addAll(result.getErrors());

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/MergeNodes.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/MergeNodes.java
@@ -63,7 +63,7 @@ public final class MergeNodes {
             Optional<ConfigNode> array1AtIndex = arrayNode1.getIndex(i);
             Optional<ConfigNode> array2AtIndex = arrayNode2.getIndex(i);
             if (array1AtIndex.isPresent() && array2AtIndex.isPresent()) {
-                String nextPath = PathUtil.pathForIndex(path, i);
+                String nextPath = PathUtil.pathForIndex(lexer, path, i);
                 GResultOf<ConfigNode> result = mergeNodes(nextPath, lexer, array1AtIndex.get(), array2AtIndex.get());
 
                 // if there are errors, add them to the error list abd do not add the merge results

--- a/gestalt-core/src/main/java/org/github/gestalt/config/parser/ConfigParser.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/parser/ConfigParser.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.parser;
 
 import org.github.gestalt.config.entity.ConfigValue;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.token.Token;
 import org.github.gestalt.config.utils.GResultOf;
@@ -18,9 +19,10 @@ public interface ConfigParser {
     /**
      * Takes in a tokenized config and returns a config node tree.
      *
+     * @param lexer lexer used to get the delimiter to build the path
      * @param configs      configs to parse
      * @param failOnErrors if we want to fail on errors while parsing or try and recover. Results can be unpredictable if it continues
      * @return the config node built
      */
-    GResultOf<ConfigNode> parse(List<Pair<List<Token>, ConfigValue>> configs, boolean failOnErrors);
+    GResultOf<ConfigNode> parse(SentenceLexer lexer, List<Pair<List<Token>, ConfigValue>> configs, boolean failOnErrors);
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/parser/MapConfigParser.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/parser/MapConfigParser.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.parser;
 import org.github.gestalt.config.entity.ConfigValue;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.entity.ValidationLevel;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ArrayNode;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
@@ -28,8 +29,8 @@ public final class MapConfigParser implements ConfigParser {
     private static final System.Logger logger = System.getLogger(MapConfigParser.class.getName());
 
     @Override
-    public GResultOf<ConfigNode> parse(List<Pair<List<Token>, ConfigValue>> configs, boolean failOnErrors) {
-        return buildConfigTree(configs, 0, failOnErrors);
+    public GResultOf<ConfigNode> parse(SentenceLexer lexer, List<Pair<List<Token>, ConfigValue>> configs, boolean failOnErrors) {
+        return buildConfigTree(lexer, configs, 0, failOnErrors);
     }
 
     /**
@@ -42,7 +43,7 @@ public final class MapConfigParser implements ConfigParser {
      * @param failOnErrors Results can be unpredictable if it continues
      * @return the ConfigNode root for the configurations at this point.
      */
-    GResultOf<ConfigNode> buildConfigTree(List<Pair<List<Token>, ConfigValue>> tokens, int index,
+    GResultOf<ConfigNode> buildConfigTree(SentenceLexer lexer, List<Pair<List<Token>, ConfigValue>> tokens, int index,
                                           boolean failOnErrors) {
 
         if (tokens == null || tokens.isEmpty()) {
@@ -50,7 +51,7 @@ public final class MapConfigParser implements ConfigParser {
         }
 
         // build the current path, mostly for logging.
-        String currentPath = PathUtil.toPath(tokens.get(0).getFirst().subList(0, index));
+        String currentPath = PathUtil.toPath(lexer, tokens.get(0).getFirst().subList(0, index));
         List<ValidationError> errorList = new ArrayList<>();
 
         // if there is only 1 token and we are at the end of the path return a valid leaf.
@@ -106,7 +107,7 @@ public final class MapConfigParser implements ConfigParser {
                 .collect(Collectors.groupingBy(tokenPair -> tokenPair.getFirst().get(index)))
                 .entrySet()
                 .stream()
-                .map(entry -> new Pair<>(entry.getKey(), buildConfigTree(entry.getValue(), index + 1, failOnErrors)))
+                .map(entry -> new Pair<>(entry.getKey(), buildConfigTree(lexer, entry.getValue(), index + 1, failOnErrors)))
                 .collect(Collectors.toList());
 
         // Get any errors and split them by level.

--- a/gestalt-core/src/main/java/org/github/gestalt/config/path/mapper/PathMapper.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/path/mapper/PathMapper.java
@@ -23,7 +23,7 @@ public interface PathMapper {
     }
 
     /**
-     * Takes a sentance and converts it into a set of tokens to navigate.
+     * Takes a sentence and converts it into a set of tokens to navigate.
      *
      * @param path     the current path we are looking in
      * @param sentence the next segment of the path to check

--- a/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessor.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/post/process/transform/TransformerPostProcessor.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.post.process.transform;
 
 import org.github.gestalt.config.entity.ValidationError;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.LeafNode;
 import org.github.gestalt.config.post.process.PostProcessor;
@@ -42,6 +43,7 @@ public final class TransformerPostProcessor implements PostProcessor {
     private int maxRecursionDepth = 5;
     private SubstitutionTreeBuilder substitutionTreeBuilder;
     private SecretConcealer secretConcealer;
+    private SentenceLexer lexer;
 
     /**
      * By default, use the service loader to load all Transformer classes.
@@ -87,6 +89,7 @@ public final class TransformerPostProcessor implements PostProcessor {
         this.maxRecursionDepth = config.getConfig().getMaxSubstitutionNestedDepth();
         this.pattern = Pattern.compile(DEFAULT_SUBSTITUTION_REGEX);
         this.secretConcealer = config.getSecretConcealer();
+        this.lexer = config.getLexer();
     }
 
     @Override
@@ -112,7 +115,7 @@ public final class TransformerPostProcessor implements PostProcessor {
     private GResultOf<String> buildSubstitutedStringList(String path, ConfigNode originalNode, List<SubstitutionNode> nodes, int depth) {
         if (depth > maxRecursionDepth) {
             return GResultOf.errors(
-                new ValidationError.ExceededMaximumNestedSubstitutionDepth(path, depth, originalNode, secretConcealer));
+                new ValidationError.ExceededMaximumNestedSubstitutionDepth(path, depth, originalNode, secretConcealer, lexer));
         }
 
         StringBuilder result = new StringBuilder();

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/source/EnvironmentConfigSource.java
@@ -10,6 +10,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +38,8 @@ public final class EnvironmentConfigSource implements ConfigSource {
     private final boolean removePrefix;
 
     private final Tags tags;
+
+    private final Pattern startsWith = Pattern.compile("^[^a-zA-Z0-9]");
 
     /**
      * Default constructor for EnvironmentConfigSource.
@@ -162,7 +166,8 @@ public final class EnvironmentConfigSource implements ConfigSource {
                     key = key.substring(prefix.length());
 
                     //if the next character is a _ or . remove that as well
-                    if (key.startsWith("_") || key.startsWith(".")) {
+
+                    if (startsWith.matcher(key).find()) {
                         key = key.substring(1);
                     }
                 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
@@ -18,6 +18,7 @@ public final class PathUtil {
 
     }
 
+
     /**
      * Returns the path for a list of tokens.
      *
@@ -48,7 +49,7 @@ public final class PathUtil {
     }
 
     /**
-     * used to generate a path wit the next key in the format path.key .
+     * used to generate a path with the next key in the format path.key .
      *
      * @param lexer lexer used to get the delimiter to build the path
      * @param path current path
@@ -57,6 +58,20 @@ public final class PathUtil {
      */
     public static String pathForKey(SentenceLexer lexer, String path, String key) {
         return path == null || path.isEmpty() ? key : path + lexer.getNormalizedDeliminator() + key;
+    }
+
+    /**
+     * used to generate a path with the next key in the format path.v1.v2 for a list of keys.
+     *
+     * @param lexer lexer used to get the delimiter to build the path
+     * @param path current path
+     * @param pathParts parts of the path to append to the root path.
+     * @return combined path.
+     */
+    public static String pathForKey(SentenceLexer lexer, String path, List<String> pathParts) {
+        return pathParts
+            .stream()
+            .reduce(path, (collectPath, key) -> pathForKey(lexer, collectPath, key));
     }
 
     /**

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
@@ -1,5 +1,6 @@
 package org.github.gestalt.config.utils;
 
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.token.ArrayToken;
 import org.github.gestalt.config.token.ObjectToken;
 import org.github.gestalt.config.token.TagToken;
@@ -20,15 +21,16 @@ public final class PathUtil {
     /**
      * Returns the path for a list of tokens.
      *
+     * @param lexer lexer used to get the delimiter to build the path
      * @param tokens list of tokens on the path.
      * @return the path built from the tokens
      */
-    public static String toPath(List<Token> tokens) {
+    public static String toPath(SentenceLexer lexer, List<Token> tokens) {
         StringBuilder pathBuilder = new StringBuilder();
         tokens.forEach(token -> {
             if (token instanceof ObjectToken) {
                 if (pathBuilder.length() != 0) {
-                    pathBuilder.append('.');
+                    pathBuilder.append(lexer.getNormalizedDeliminator());
                 }
                 pathBuilder.append(((ObjectToken) token).getName());
             } else if (token instanceof ArrayToken) {
@@ -48,12 +50,13 @@ public final class PathUtil {
     /**
      * used to generate a path wit the next key in the format path.key .
      *
+     * @param lexer lexer used to get the delimiter to build the path
      * @param path current path
      * @param key  current key
      * @return path for key
      */
-    public static String pathForKey(String path, String key) {
-        return path == null || path.isEmpty() ? key : path + "." + key;
+    public static String pathForKey(SentenceLexer lexer, String path, String key) {
+        return path == null || path.isEmpty() ? key : path + lexer.getNormalizedDeliminator() + key;
     }
 
     /**
@@ -64,7 +67,17 @@ public final class PathUtil {
      * @return path for index
      */
     public static String pathForIndex(String path, int index) {
-        return path == null || path.isEmpty() ? "[" + index + "]" : path + "[" + index + "]";
+        return path == null || path.isEmpty() ? forIndex(index) : path + forIndex(index);
+    }
+
+    /**
+     * used to generate the next index in the format [index] .
+     *
+     * @param index current index
+     * @return path for index
+     */
+    public static String forIndex(int index) {
+        return  "[" + index + "]";
     }
 }
 

--- a/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/utils/PathUtil.java
@@ -34,12 +34,12 @@ public final class PathUtil {
                 }
                 pathBuilder.append(((ObjectToken) token).getName());
             } else if (token instanceof ArrayToken) {
-                pathBuilder.append('[');
+                pathBuilder.append(lexer.getNormalizedArrayOpenTag());
                 pathBuilder.append(((ArrayToken) token).getIndex());
-                pathBuilder.append(']');
+                pathBuilder.append(lexer.getNormalizedArrayCloseTag());
             } else if (token instanceof TagToken) {
                 pathBuilder.append(((TagToken) token).getTag());
-                pathBuilder.append('=');
+                pathBuilder.append(lexer.getNormalizedMapTag());
                 pathBuilder.append(((TagToken) token).getValue());
             }
         });
@@ -62,22 +62,24 @@ public final class PathUtil {
     /**
      * used to generate a path wit the next index in the format path[index] .
      *
+     * @param lexer lexer used to get the delimiter to build the path
      * @param path  current path
      * @param index current index
      * @return path for index
      */
-    public static String pathForIndex(String path, int index) {
-        return path == null || path.isEmpty() ? forIndex(index) : path + forIndex(index);
+    public static String pathForIndex(SentenceLexer lexer, String path, int index) {
+        return path == null || path.isEmpty() ? forIndex(lexer, index) : path + forIndex(lexer, index);
     }
 
     /**
      * used to generate the next index in the format [index] .
      *
+     * @param lexer lexer used to get the delimiter to build the path
      * @param index current index
      * @return path for index
      */
-    public static String forIndex(int index) {
-        return  "[" + index + "]";
+    public static String forIndex(SentenceLexer lexer, int index) {
+        return  lexer.getNormalizedArrayOpenTag() + index + lexer.getNormalizedArrayCloseTag();
     }
 }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ArrayDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ArrayDecoderTest.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.*;
 import org.github.gestalt.config.path.mapper.StandardPathMapper;
@@ -96,7 +97,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -121,7 +122,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -147,7 +148,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -168,7 +169,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("0.1111, 0.22"),
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -185,7 +186,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), new LeafNode(null),
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -201,7 +202,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -217,7 +218,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes, TypeCapture.of(String[].class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -230,7 +231,7 @@ class ArrayDecoderTest {
         ArrayDecoder decoder = new ArrayDecoder();
 
         GResultOf<Object[]> values = decoder.decode("db.hosts", Tags.of(), nodes, TypeCapture.of(String[].class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -250,7 +251,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -279,7 +280,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), nodes,
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -301,7 +302,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(),
-            new MapNode(new HashMap<>()), TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            new MapNode(new HashMap<>()), TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -316,7 +317,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), new MapNode(null),
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -331,7 +332,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), new ArrayNode(List.of()),
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -344,7 +345,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), new ArrayNode(null),
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -357,7 +358,7 @@ class ArrayDecoderTest {
         ArrayDecoder<Double> decoder = new ArrayDecoder<>();
 
         GResultOf<Double[]> values = decoder.decode("db.hosts", Tags.of(), null,
-            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -372,7 +373,7 @@ class ArrayDecoderTest {
         ArrayDecoder<String> decoder = new ArrayDecoder<>();
 
         GResultOf<String[]> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("a,b,c\\,d"),
-            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String[].class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigDecimalDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigDecimalDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -75,7 +76,7 @@ class BigDecimalDecoderTest {
         BigDecimalDecoder doubleDecoder = new BigDecimalDecoder();
 
         GResultOf<BigDecimal> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124.5"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigDecimal.valueOf(124.5f), result.results());
@@ -87,7 +88,7 @@ class BigDecimalDecoderTest {
         BigDecimalDecoder doubleDecoder = new BigDecimalDecoder();
 
         GResultOf<BigDecimal> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124.5"), new TypeCapture<Double>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigDecimal.valueOf(124.5f), result.results());
@@ -99,7 +100,7 @@ class BigDecimalDecoderTest {
         BigDecimalDecoder doubleDecoder = new BigDecimalDecoder();
 
         GResultOf<BigDecimal> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigDecimal.valueOf(124.0f), result.results());
@@ -111,7 +112,7 @@ class BigDecimalDecoderTest {
         BigDecimalDecoder doubleDecoder = new BigDecimalDecoder();
 
         GResultOf<BigDecimal> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigIntegerDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BigIntegerDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -71,7 +72,7 @@ class BigIntegerDecoderTest {
         BigIntegerDecoder doubleDecoder = new BigIntegerDecoder();
 
         GResultOf<BigInteger> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigInteger.valueOf(124), result.results());
@@ -83,7 +84,7 @@ class BigIntegerDecoderTest {
         BigIntegerDecoder doubleDecoder = new BigIntegerDecoder();
 
         GResultOf<BigInteger> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124"), new TypeCapture<Double>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigInteger.valueOf(124), result.results());
@@ -95,7 +96,7 @@ class BigIntegerDecoderTest {
         BigIntegerDecoder doubleDecoder = new BigIntegerDecoder();
 
         GResultOf<BigInteger> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(BigInteger.valueOf(124), result.results());
@@ -107,7 +108,7 @@ class BigIntegerDecoderTest {
         BigIntegerDecoder doubleDecoder = new BigIntegerDecoder();
 
         GResultOf<BigInteger> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -123,7 +124,7 @@ class BigIntegerDecoderTest {
         BigIntegerDecoder doubleDecoder = new BigIntegerDecoder();
 
         GResultOf<BigInteger> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124.2"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BooleanDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/BooleanDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class BooleanDecoderTest {
         BooleanDecoder decoder = new BooleanDecoder();
 
         GResultOf<Boolean> result = decoder.decode("db.enabled", Tags.of(), new LeafNode("true"),
-            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results());
@@ -76,7 +77,7 @@ class BooleanDecoderTest {
         BooleanDecoder decoder = new BooleanDecoder();
 
         GResultOf<Boolean> result = decoder.decode("db.enabled", Tags.of(), new LeafNode("false"),
-            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertFalse(result.results());
@@ -87,7 +88,7 @@ class BooleanDecoderTest {
         BooleanDecoder decoder = new BooleanDecoder();
 
         GResultOf<Boolean> result = decoder.decode("db.enabled", Tags.of(), new LeafNode(null),
-            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Boolean.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ByteDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ByteDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -67,7 +68,7 @@ class ByteDecoderTest {
         ByteDecoder decoder = new ByteDecoder();
 
         GResultOf<Byte> result = decoder.decode("db.port", Tags.of(), new LeafNode("a"),
-            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals("a".getBytes(Charset.defaultCharset())[0], result.results());
@@ -79,7 +80,7 @@ class ByteDecoderTest {
         ByteDecoder decoder = new ByteDecoder();
 
         GResultOf<Byte> result = decoder.decode("db.port", Tags.of(), new LeafNode("aaa"),
-            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertEquals((byte) 97, result.results());
@@ -94,7 +95,7 @@ class ByteDecoderTest {
         ByteDecoder decoder = new ByteDecoder();
 
         GResultOf<Byte> result = decoder.decode("db.port", Tags.of(), new LeafNode(""),
-            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Byte.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/CharDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/CharDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -64,7 +65,7 @@ class CharDecoderTest {
         CharDecoder decoder = new CharDecoder();
 
         GResultOf<Character> result = decoder.decode("db.port", Tags.of(), new LeafNode("a"),
-            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals('a', result.results());
@@ -76,7 +77,7 @@ class CharDecoderTest {
         CharDecoder decoder = new CharDecoder();
 
         GResultOf<Character> result = decoder.decode("db.port", Tags.of(), new LeafNode("aaa"),
-            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -93,7 +94,7 @@ class CharDecoderTest {
         CharDecoder decoder = new CharDecoder();
 
         GResultOf<Character> result = decoder.decode("db.port", Tags.of(), new LeafNode(""),
-            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Character.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ConfigDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ConfigDecoderTest.java
@@ -5,6 +5,7 @@ import org.github.gestalt.config.entity.ConfigContainer;
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -78,7 +79,7 @@ class ConfigDecoderTest {
         ConfigDecoder decoder = new ConfigDecoder();
 
         GResultOf<ConfigContainer<?>> result = decoder.decode("db.user", Tags.of(), new LeafNode("test"),
-            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null));
+            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(true, result.results().isPresent());
@@ -91,7 +92,7 @@ class ConfigDecoderTest {
         ConfigDecoder decoder = new ConfigDecoder();
 
         GResultOf<ConfigContainer<?>> result = decoder.decode("db.user", Tags.of(), new LeafNode(null),
-            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null));
+            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -106,7 +107,7 @@ class ConfigDecoderTest {
         ConfigDecoder decoder = new ConfigDecoder();
 
         GResultOf<ConfigContainer<?>> result = decoder.decode("db.user", Tags.of(), null,
-            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null));
+            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -121,7 +122,7 @@ class ConfigDecoderTest {
         ConfigDecoder decoder = new ConfigDecoder();
 
         GResultOf<ConfigContainer<?>> result = decoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null));
+            new TypeCapture<ConfigContainer<String>>() {}, new DecoderContext(decoderService, gestalt, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DateDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DateDecoderTest.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -73,7 +74,7 @@ class DateDecoderTest {
 
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new LeafNode(instant.toString()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -93,7 +94,7 @@ class DateDecoderTest {
 
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new LeafNode(instant.toString()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -113,7 +114,7 @@ class DateDecoderTest {
         Instant instant = ldt.atZone(ZoneId.systemDefault()).toInstant();
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new LeafNode(date),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -128,7 +129,7 @@ class DateDecoderTest {
         String now = "not a date";
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -144,7 +145,7 @@ class DateDecoderTest {
         DateDecoder decoder = new DateDecoder();
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -159,7 +160,7 @@ class DateDecoderTest {
         DateDecoder decoder = new DateDecoder();
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -174,7 +175,7 @@ class DateDecoderTest {
         DateDecoder decoder = new DateDecoder();
 
         GResultOf<Date> result = decoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderContextTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderContextTest.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.Gestalt;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -10,29 +11,32 @@ class DecoderContextTest {
 
     @Test
     void equals() {
+        var lexer1 = new PathLexer();
         Gestalt gestalt = Mockito.mock();
         Gestalt gestalt2 = Mockito.mock();
         DecoderService  decoderService  = Mockito.mock();
         DecoderService  decoderService2  = Mockito.mock();
         SecretConcealer secretConcealer = Mockito.mock();
         SecretConcealer secretConcealer2 = Mockito.mock();
-        DecoderContext decoderContext = new DecoderContext(decoderService, gestalt, secretConcealer);
-        DecoderContext decoderContext1 = new DecoderContext(decoderService, gestalt, secretConcealer);
-        DecoderContext decoderContext3 = new DecoderContext(decoderService, gestalt2, secretConcealer2);
-        DecoderContext decoderContext4 = new DecoderContext(decoderService2, gestalt, secretConcealer2);
+        DecoderContext decoderContext = new DecoderContext(decoderService, gestalt, secretConcealer, lexer1);
+        DecoderContext decoderContext1 = new DecoderContext(decoderService, gestalt, secretConcealer, lexer1);
+        DecoderContext decoderContext3 = new DecoderContext(decoderService, gestalt2, secretConcealer2, lexer1);
+        DecoderContext decoderContext4 = new DecoderContext(decoderService2, gestalt, secretConcealer2, lexer1);
+        DecoderContext decoderContext5 = new DecoderContext(decoderService2, gestalt, secretConcealer2, new PathLexer("_"));
 
         Assertions.assertEquals(decoderContext, decoderContext);
         Assertions.assertEquals(decoderContext, decoderContext1);
         Assertions.assertNotEquals(decoderContext, 0);
         Assertions.assertNotEquals(decoderContext, decoderContext3);
         Assertions.assertNotEquals(decoderContext, decoderContext4);
+        Assertions.assertNotEquals(decoderContext4, decoderContext5);
     }
 
     @Test
     void hashCodeTest() {
         Gestalt gestalt = Mockito.mock();
         DecoderService decoderService = Mockito.mock();
-        DecoderContext decoderContext = new DecoderContext(decoderService, gestalt, null);
+        DecoderContext decoderContext = new DecoderContext(decoderService, gestalt, null, new PathLexer());
         Assertions.assertTrue(decoderContext.hashCode() != 0);
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderRegistryTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DecoderRegistryTest.java
@@ -4,6 +4,7 @@ import org.github.gestalt.config.annotations.ConfigPriority;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.node.ConfigNodeService;
@@ -195,7 +196,7 @@ class DecoderRegistryTest {
         ConfigNode leaf = new LeafNode("value");
 
         GResultOf<String> test = decoderRegistry.decodeNode("test", Tags.of(), leaf, TypeCapture.of(String.class),
-            new DecoderContext(decoderRegistry, null, null));
+            new DecoderContext(decoderRegistry, null, null, new PathLexer()));
         Assertions.assertTrue(test.hasResults());
         Assertions.assertFalse(test.hasErrors());
 
@@ -210,7 +211,7 @@ class DecoderRegistryTest {
         ConfigNode leaf = new LeafNode("100");
 
         GResultOf<Long> test = decoderRegistry.decodeNode("test", Tags.of(), leaf, TypeCapture.of(Long.class),
-            new DecoderContext(decoderRegistry, null, null));
+            new DecoderContext(decoderRegistry, null, null, new PathLexer()));
         Assertions.assertTrue(test.hasResults());
         Assertions.assertFalse(test.hasErrors());
 
@@ -226,7 +227,7 @@ class DecoderRegistryTest {
         ConfigNode leaf = new LeafNode("100");
 
         GResultOf<Long> test = decoderRegistry.decodeNode("test", Tags.of(), leaf, TypeCapture.of(Long.class),
-            new DecoderContext(decoderRegistry, null, null));
+            new DecoderContext(decoderRegistry, null, null, new PathLexer()));
         Assertions.assertTrue(test.hasResults());
         Assertions.assertFalse(test.hasErrors());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DoubleDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DoubleDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class DoubleDecoderTest {
         DoubleDecoder doubleDecoder = new DoubleDecoder();
 
         GResultOf<Double> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124.5"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124.5f, result.results());
@@ -77,7 +78,7 @@ class DoubleDecoderTest {
         DoubleDecoder doubleDecoder = new DoubleDecoder();
 
         GResultOf<Double> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124.5"), new TypeCapture<Double>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124.5f, result.results());
@@ -89,7 +90,7 @@ class DoubleDecoderTest {
         DoubleDecoder doubleDecoder = new DoubleDecoder();
 
         GResultOf<Double> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124, result.results());
@@ -101,7 +102,7 @@ class DoubleDecoderTest {
         DoubleDecoder doubleDecoder = new DoubleDecoder();
 
         GResultOf<Double> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Double.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/DurationDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class DurationDecoderTest {
         DurationDecoder decoder = new DurationDecoder();
 
         GResultOf<Duration> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(Duration.ofMillis(124L), result.results());
@@ -77,7 +78,7 @@ class DurationDecoderTest {
         DurationDecoder decoder = new DurationDecoder();
 
         GResultOf<Duration> result = decoder.decode("db.port", Tags.of(), new LeafNode("PT20S"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(Duration.ofSeconds(20), result.results());
@@ -89,7 +90,7 @@ class DurationDecoderTest {
         DurationDecoder decoder = new DurationDecoder();
 
         GResultOf<Duration> result = decoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/EnumDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/EnumDecoderTest.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class EnumDecoderTest {
         EnumDecoder decoder = new EnumDecoder();
 
         GResultOf<Colours> result = decoder.decode("db.port", Tags.of(), new LeafNode("RED"),
-            TypeCapture.of(Colours.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Colours.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(Colours.RED, result.results());
@@ -78,7 +79,7 @@ class EnumDecoderTest {
         EnumDecoder decoder = new EnumDecoder();
 
         GResultOf<Colours> result = decoder.decode("db.port", Tags.of(), new LeafNode("pink"),
-            TypeCapture.of(Colours.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Colours.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertEquals(1, result.getErrors().size());
@@ -93,7 +94,7 @@ class EnumDecoderTest {
         EnumDecoder decoder = new EnumDecoder();
 
         GResultOf<Colours> result = decoder.decode("db.port", Tags.of(), new LeafNode("pink"),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertEquals(1, result.getErrors().size());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FileDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FileDecoderTest.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.integration.GestaltIntegrationTests;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class FileDecoderTest {
         URL defaultFileURL = GestaltIntegrationTests.class.getClassLoader().getResource("default.properties");
         File defaultFile = new File(defaultFileURL.getFile());
         GResultOf<File> result = decoder.decode("db.user", Tags.of(), new LeafNode(defaultFile.getAbsolutePath()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -78,7 +79,7 @@ class FileDecoderTest {
         FileDecoder stringDecoder = new FileDecoder();
 
         GResultOf<File> result = stringDecoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -93,7 +94,7 @@ class FileDecoderTest {
         FileDecoder stringDecoder = new FileDecoder();
 
         GResultOf<File> result = stringDecoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -108,7 +109,7 @@ class FileDecoderTest {
         FileDecoder stringDecoder = new FileDecoder();
 
         GResultOf<File> result = stringDecoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FloatDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/FloatDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -64,7 +65,7 @@ class FloatDecoderTest {
         FloatDecoder floatDecoder = new FloatDecoder();
 
         GResultOf<Float> result = floatDecoder.decode("db.timeout", Tags.of(), new LeafNode("124.5"),
-            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124.5f, result.results());
@@ -76,7 +77,7 @@ class FloatDecoderTest {
         FloatDecoder floatDecoder = new FloatDecoder();
 
         GResultOf<Float> result = floatDecoder.decode("db.timeout", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124, result.results());
@@ -88,7 +89,7 @@ class FloatDecoderTest {
         FloatDecoder floatDecoder = new FloatDecoder();
 
         GResultOf<Float> result = floatDecoder.decode("db.timeout", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Float.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/InstantDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/InstantDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -63,7 +64,7 @@ class InstantDecoderTest {
         String now = Instant.now().toString();
 
         GResultOf<Instant> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -78,7 +79,7 @@ class InstantDecoderTest {
         String now = "not a date";
 
         GResultOf<Instant> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -94,7 +95,7 @@ class InstantDecoderTest {
         InstantDecoder decoder = new InstantDecoder();
 
         GResultOf<Instant> result = decoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -109,7 +110,7 @@ class InstantDecoderTest {
         InstantDecoder decoder = new InstantDecoder();
 
         GResultOf<Instant> result = decoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -124,7 +125,7 @@ class InstantDecoderTest {
         InstantDecoder decoder = new InstantDecoder();
 
         GResultOf<Instant> result = decoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/IntegerDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/IntegerDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -64,7 +65,7 @@ class IntegerDecoderTest {
         IntegerDecoder integerDecoder = new IntegerDecoder();
 
         GResultOf<Integer> result = integerDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Integer.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Integer.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124, result.results());
@@ -76,7 +77,7 @@ class IntegerDecoderTest {
         IntegerDecoder integerDecoder = new IntegerDecoder();
 
         GResultOf<Integer> result = integerDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Integer.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Integer.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -93,7 +94,7 @@ class IntegerDecoderTest {
 
         GResultOf<Integer> result = decoder.decode("db.port", Tags.of(),
             new LeafNode("12345678901234567890123456789012345678901234567890123456789"), TypeCapture.of(Integer.class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ListDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ListDecoderTest.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.*;
 import org.github.gestalt.config.path.mapper.StandardPathMapper;
@@ -91,7 +92,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -113,7 +114,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -136,7 +137,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<ArrayList<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -159,7 +160,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<AbstractList<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -182,7 +183,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<CopyOnWriteArrayList<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -205,7 +206,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<LinkedList<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -228,7 +229,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Stack<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -251,7 +252,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Vector<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -274,7 +275,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -297,7 +298,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -316,7 +317,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("0.1111, 0.22"), new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -331,7 +332,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("a,b,c\\,d"), new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -347,7 +348,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode(null), new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -362,7 +363,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), null, new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -378,7 +379,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -391,7 +392,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -404,7 +405,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -425,7 +426,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -455,7 +456,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -476,7 +477,7 @@ class ListDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), new MapNode(new HashMap<>()), new TypeCapture<List<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -67,7 +68,7 @@ class LocalDateDecoderTest {
         LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE);
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new LeafNode(date),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -83,7 +84,7 @@ class LocalDateDecoderTest {
         LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE);
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new LeafNode(date),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -99,7 +100,7 @@ class LocalDateDecoderTest {
         LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ISO_LOCAL_DATE);
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new LeafNode(date),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -114,7 +115,7 @@ class LocalDateDecoderTest {
         String now = "not a date";
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -130,7 +131,7 @@ class LocalDateDecoderTest {
         LocalDateDecoder decoder = new LocalDateDecoder();
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -145,7 +146,7 @@ class LocalDateDecoderTest {
         LocalDateDecoder decoder = new LocalDateDecoder();
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -160,7 +161,7 @@ class LocalDateDecoderTest {
         LocalDateDecoder decoder = new LocalDateDecoder();
 
         GResultOf<LocalDate> result = decoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateTimeDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LocalDateTimeDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -65,7 +66,7 @@ class LocalDateTimeDecoderTest {
         String now = Instant.now().toString();
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -80,7 +81,7 @@ class LocalDateTimeDecoderTest {
         String now = Instant.now().toString();
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -97,7 +98,7 @@ class LocalDateTimeDecoderTest {
         LocalDateTime localDate = LocalDateTime.parse(date, DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new LeafNode(date),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -112,7 +113,7 @@ class LocalDateTimeDecoderTest {
         String now = "not a date";
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new LeafNode(now),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -128,7 +129,7 @@ class LocalDateTimeDecoderTest {
         LocalDateTimeDecoder decoder = new LocalDateTimeDecoder();
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -143,7 +144,7 @@ class LocalDateTimeDecoderTest {
         LocalDateTimeDecoder decoder = new LocalDateTimeDecoder();
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -158,7 +159,7 @@ class LocalDateTimeDecoderTest {
         LocalDateTimeDecoder decoder = new LocalDateTimeDecoder();
 
         GResultOf<LocalDateTime> result = decoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LongDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/LongDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -64,7 +65,7 @@ class LongDecoderTest {
         LongDecoder longDecoder = new LongDecoder();
 
         GResultOf<Long> result = longDecoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(124L, result.results());
@@ -76,7 +77,7 @@ class LongDecoderTest {
         LongDecoder longDecoder = new LongDecoder();
 
         GResultOf<Long> result = longDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -93,7 +94,7 @@ class LongDecoderTest {
 
         GResultOf<Long> result = decoder.decode("db.port", Tags.of(),
             new LeafNode("12345678901234567890123456789012345678901234567890123456"), TypeCapture.of(Long.class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
@@ -87,7 +87,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -109,7 +109,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<HashMap<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -132,7 +132,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<TreeMap<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -155,7 +155,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<LinkedHashMap<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -182,7 +182,7 @@ class MapDecoderTest {
         // hashMap. In the real case it will not get called as the canDecode will return false
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Pair<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -206,7 +206,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<Integer, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -222,7 +222,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100,uri=300,password=6000"),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -238,7 +238,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100, uri=300 , password=6000"),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -254,7 +254,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100, uri=300, , password=6000"),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -270,7 +270,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100\\, uri=300 , password=6000"),
             new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -285,7 +285,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode(""),
             new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -299,7 +299,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100, uri , password=6000"),
             new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -316,7 +316,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode(null),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -343,7 +343,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<String, User>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -373,7 +373,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -383,6 +383,37 @@ class MapDecoderTest {
         Assertions.assertEquals(123, results.get("settings.timeout"));
         Assertions.assertEquals(2, results.get("settings.retry.times"));
         Assertions.assertEquals(7, results.get("settings.retry.delay"));
+    }
+
+    @Test
+    void decodeNestedMapCustomDelimiter() {
+        Map<String, ConfigNode> retrySetting = new HashMap<>();
+        retrySetting.put("times", new LeafNode("2"));
+        retrySetting.put("delay", new LeafNode("7"));
+
+        Map<String, ConfigNode> settings = new HashMap<>();
+        settings.put("timeout", new LeafNode("123"));
+        settings.put("retry", new MapNode(retrySetting));
+
+        Map<String, ConfigNode> configs = new HashMap<>();
+        configs.put("port", new LeafNode("100"));
+        configs.put("uri", new LeafNode("300"));
+        configs.put("settings", new MapNode(settings));
+
+        MapDecoder decoder = new MapDecoder();
+
+        GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
+            new TypeCapture<Map<String, Integer>>() {
+            }, new DecoderContext(decoderService, null, null, new PathLexer(":")));
+        Assertions.assertTrue(result.hasResults());
+        Assertions.assertFalse(result.hasErrors());
+
+        Map<String, Integer> results = (Map<String, Integer>) result.results();
+        Assertions.assertEquals(100, results.get("port"));
+        Assertions.assertEquals(300, results.get("uri"));
+        Assertions.assertEquals(123, results.get("settings:timeout"));
+        Assertions.assertEquals(2, results.get("settings:retry:times"));
+        Assertions.assertEquals(7, results.get("settings:retry:delay"));
     }
 
     @Test
@@ -404,7 +435,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -427,7 +458,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(),
             new MapNode(configs), new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -454,7 +485,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(),
             new MapNode(configs), new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -479,7 +510,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(),
             new MapNode(configs), new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -501,7 +532,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(),
             new ArrayNode(List.of()), new TypeCapture<Map<String, String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -522,7 +553,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<List<String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -544,7 +575,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Integer>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -559,7 +590,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(null),
             new TypeCapture<List<String>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -573,7 +604,7 @@ class MapDecoderTest {
     void decodeNullNode() {
         MapDecoder decoder = new MapDecoder();
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), null, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -594,7 +625,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<Integer, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -626,7 +657,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
             new TypeCapture<Map<Integer, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -658,7 +689,7 @@ class MapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode(null, Tags.of(), new MapNode(configs),
             new TypeCapture<Map<Integer, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
@@ -265,7 +265,7 @@ class MapDecoderTest {
     }
 
     @Test
-    void decodeLeafEscape() {
+    void decodeLeafSeparatorEscape() {
         MapDecoder decoder = new MapDecoder();
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100\\, uri=300 , password=6000"),
@@ -275,8 +275,24 @@ class MapDecoderTest {
         Assertions.assertFalse(result.hasErrors());
 
         Map<String, String> results = (Map<String, String>) result.results();
-        Assertions.assertEquals("100\\, uri=300", results.get("port"));
+        Assertions.assertEquals("100, uri=300", results.get("port"));
         Assertions.assertEquals("6000", results.get("password"));
+    }
+
+    @Test
+    void decodeLeafValueSeparatorEscape() {
+        MapDecoder decoder = new MapDecoder();
+
+        GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port\\=100=75,uri=300,password=6000"),
+            new TypeCapture<Map<String, Integer>>() {
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
+        Assertions.assertTrue(result.hasResults());
+        Assertions.assertFalse(result.hasErrors());
+
+        Map<String, Integer> results = (Map<String, Integer>) result.results();
+        Assertions.assertEquals(75, results.get("port=100"));
+        Assertions.assertEquals(300, results.get("uri"));
+        Assertions.assertEquals(6000, results.get("password"));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ObjectDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ObjectDecoderTest.java
@@ -99,7 +99,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfo.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfo.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -121,7 +122,8 @@ class ObjectDecoderTest {
         configs.put("timeout", new LeafNode("10"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoExtended.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoExtended.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -144,7 +146,7 @@ class ObjectDecoderTest {
         configs.put("user", new LeafNode("Ted"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoExtended.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoExtended.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -173,7 +175,8 @@ class ObjectDecoderTest {
         configs.put("timeout", new LeafNode("10"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoExtendedDefault.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoExtendedDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -196,7 +199,8 @@ class ObjectDecoderTest {
         configs.put("user", new LeafNode("Ted"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoExtendedDefault.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoExtendedDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -225,7 +229,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoNoDefaultConstructor.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoNoDefaultConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -245,7 +250,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoPrivateConstructor.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoPrivateConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -264,7 +270,8 @@ class ObjectDecoderTest {
         configs.put("uri", new LeafNode("mysql.com"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -290,7 +297,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoSetterChangeValue.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoSetterChangeValue.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -310,7 +318,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoIntegerPortNonNullGetter.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoIntegerPortNonNullGetter.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
@@ -340,7 +349,8 @@ class ObjectDecoderTest {
         //configs.put("enabled", new LeafNode("true")); missing
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoBooleanEnabledNonNullGetter.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoBooleanEnabledNonNullGetter.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
@@ -370,7 +380,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfo.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfo.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -400,7 +411,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -432,7 +444,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoIntegerPort.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoIntegerPort.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -460,7 +473,7 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoStatic.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoStatic.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -480,7 +493,7 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -497,7 +510,7 @@ class ObjectDecoderTest {
         Map<String, ConfigNode> configs = new HashMap<>();
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -530,7 +543,7 @@ class ObjectDecoderTest {
         configs.put("port", new LeafNode("100"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -561,7 +574,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfo.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfo.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -590,7 +604,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfo.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfo.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -610,7 +625,8 @@ class ObjectDecoderTest {
         ObjectDecoder decoder = new ObjectDecoder();
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(null), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            new MapNode(null), TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -649,7 +665,8 @@ class ObjectDecoderTest {
         ObjectDecoder decoder = new ObjectDecoder();
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(null), TypeCapture.of(DBInfoStatic.class), new DecoderContext(decoderService, null, null));
+            new MapNode(null), TypeCapture.of(DBInfoStatic.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -668,7 +685,8 @@ class ObjectDecoderTest {
         ObjectDecoder decoder = new ObjectDecoder();
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            null, TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            null, TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -683,7 +701,8 @@ class ObjectDecoderTest {
         ObjectDecoder decoder = new ObjectDecoder();
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -705,7 +724,8 @@ class ObjectDecoderTest {
         configs.put("idletimeoutsec", new LeafNode("1000"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPool.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPool.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -736,7 +756,7 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoAnnotations.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoAnnotations.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -756,7 +776,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoAnnotationsLong.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoAnnotationsLong.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -775,7 +796,7 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoAnnotations.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoAnnotations.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -801,7 +822,8 @@ class ObjectDecoderTest {
 
         GResultOf<Object> result =
             decoder.decode("db.host", Tags.of(), new MapNode(configs),
-                TypeCapture.of(DBInfoAnnotationsDefault.class), new DecoderContext(decoderService, null, null));
+                TypeCapture.of(DBInfoAnnotationsDefault.class),
+                new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -826,7 +848,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoBadAnnotations.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoBadAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -855,7 +878,7 @@ class ObjectDecoderTest {
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
             new MapNode(configs), TypeCapture.of(DBInfoBadAnnotationsWithClassDefault.class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
@@ -887,7 +910,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -907,7 +931,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotationsLong.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotationsLong.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -926,7 +951,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -951,7 +977,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotationsDefault.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoMethodAnnotationsDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -976,7 +1003,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoBadMethodAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoBadMethodAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1006,7 +1034,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoBothAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoBothAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -1026,7 +1055,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoBothAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoBothAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1052,7 +1082,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(ObjectWithDefaultsWrapper.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(ObjectWithDefaultsWrapper.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1083,7 +1114,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(ObjectWithDefaultsPrimitive.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(ObjectWithDefaultsPrimitive.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1113,7 +1145,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(ObjectWithWithoutDefaultsPrimitive.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(ObjectWithWithoutDefaultsPrimitive.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1143,7 +1176,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(ObjectWithoutDefaultsWrapper.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(ObjectWithoutDefaultsWrapper.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -1174,7 +1208,8 @@ class ObjectDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(ObjectWithZeroDefaultsWrapper.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(ObjectWithZeroDefaultsWrapper.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDecoderTest.java
@@ -69,7 +69,7 @@ class OptionalDecoderTest {
         OptionalDecoder decoder = new OptionalDecoder();
 
         GResultOf<Optional<?>> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"), new TypeCapture<Optional<Integer>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -82,7 +82,7 @@ class OptionalDecoderTest {
         OptionalDecoder decoder = new OptionalDecoder();
 
         GResultOf<Optional<?>> result = decoder.decode("db.port", Tags.of(), new LeafNode(null), new TypeCapture<Optional<Integer>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -103,7 +103,7 @@ class OptionalDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Optional<?>> result = decoder.decode("db", Tags.of(), new MapNode(configs), new TypeCapture<Optional<DBInfoOptional>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -123,7 +123,7 @@ class OptionalDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Optional<?>> result = decoder.decode("db", Tags.of(), new MapNode(configs), new TypeCapture<Optional<DBInfoOptional>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -148,7 +148,7 @@ class OptionalDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Optional<?>> result = decoder.decode("db", Tags.of(), new MapNode(configs), new TypeCapture<Optional<DBInfoOptional1>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -168,7 +168,7 @@ class OptionalDecoderTest {
         OptionalDecoder decoder = new OptionalDecoder();
 
         GResultOf<Optional<?>> result = decoder.decode("db.port", Tags.of(), null, new TypeCapture<Optional<Integer>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -183,7 +183,7 @@ class OptionalDecoderTest {
         OptionalDecoder integerDecoder = new OptionalDecoder();
 
         GResultOf<Optional<?>> result = integerDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            new TypeCapture<Optional<Integer>>() { }, new DecoderContext(decoderService, null, null));
+            new TypeCapture<Optional<Integer>>() { }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertEquals(Optional.empty(), result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDoubleDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalDoubleDecoderTest.java
@@ -70,7 +70,7 @@ class OptionalDoubleDecoderTest {
         OptionalDoubleDecoder decoder = new OptionalDoubleDecoder();
 
         GResultOf<OptionalDouble> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"), new TypeCapture<OptionalDouble>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -83,7 +83,7 @@ class OptionalDoubleDecoderTest {
         OptionalDoubleDecoder decoder = new OptionalDoubleDecoder();
 
         GResultOf<OptionalDouble> result = decoder.decode("db.port", Tags.of(), new LeafNode(null), new TypeCapture<OptionalDouble>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -99,7 +99,7 @@ class OptionalDoubleDecoderTest {
         OptionalDoubleDecoder decoder = new OptionalDoubleDecoder();
 
         GResultOf<OptionalDouble> result = decoder.decode("db.port", Tags.of(), null,
-            TypeCapture.of(OptionalDouble.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalDouble.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -114,7 +114,7 @@ class OptionalDoubleDecoderTest {
         OptionalDoubleDecoder doubleDecoder = new OptionalDoubleDecoder();
 
         GResultOf<OptionalDouble> result = doubleDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(OptionalDouble.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalDouble.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertEquals(OptionalDouble.empty(), result.results());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalIntDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalIntDecoderTest.java
@@ -70,7 +70,7 @@ class OptionalIntDecoderTest {
         OptionalIntDecoder decoder = new OptionalIntDecoder();
 
         GResultOf<OptionalInt> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"), new TypeCapture<OptionalInt>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -83,7 +83,7 @@ class OptionalIntDecoderTest {
         OptionalIntDecoder decoder = new OptionalIntDecoder();
 
         GResultOf<OptionalInt> result = decoder.decode("db.port", Tags.of(), new LeafNode(null), new TypeCapture<OptionalInt>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -99,7 +99,7 @@ class OptionalIntDecoderTest {
         OptionalIntDecoder decoder = new OptionalIntDecoder();
 
         GResultOf<OptionalInt> result = decoder.decode("db.port", Tags.of(), null,
-            TypeCapture.of(OptionalInt.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalInt.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -114,7 +114,7 @@ class OptionalIntDecoderTest {
         OptionalIntDecoder integerDecoder = new OptionalIntDecoder();
 
         GResultOf<OptionalInt> result = integerDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(OptionalInt.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalInt.class), new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertEquals(OptionalInt.empty(), result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalLongDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/OptionalLongDecoderTest.java
@@ -70,7 +70,7 @@ class OptionalLongDecoderTest {
         OptionalLongDecoder decoder = new OptionalLongDecoder();
 
         GResultOf<OptionalLong> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"), new TypeCapture<OptionalLong>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertTrue(result.results().isPresent());
@@ -83,7 +83,7 @@ class OptionalLongDecoderTest {
         OptionalLongDecoder decoder = new OptionalLongDecoder();
 
         GResultOf<OptionalLong> result = decoder.decode("db.port", Tags.of(), new LeafNode(null), new TypeCapture<OptionalLong>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -99,7 +99,7 @@ class OptionalLongDecoderTest {
         OptionalLongDecoder decoder = new OptionalLongDecoder();
 
         GResultOf<OptionalLong> result = decoder.decode("db.port", Tags.of(), null,
-            TypeCapture.of(OptionalLong.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalLong.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertFalse(result.results().isPresent());
@@ -115,7 +115,7 @@ class OptionalLongDecoderTest {
         OptionalLongDecoder longDecoder = new OptionalLongDecoder();
 
         GResultOf<OptionalLong> result = longDecoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(OptionalLong.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(OptionalLong.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertEquals(OptionalLong.empty(), result.results());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PathDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PathDecoderTest.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.decoder;
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
 import org.github.gestalt.config.integration.GestaltIntegrationTests;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -66,7 +67,7 @@ class PathDecoderTest {
         URL defaultFileURL = GestaltIntegrationTests.class.getClassLoader().getResource("default.properties");
         File defaultFile = new File(defaultFileURL.getFile());
         GResultOf<Path> result = decoder.decode("db.user", Tags.of(), new LeafNode(defaultFile.getAbsolutePath()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -79,7 +80,7 @@ class PathDecoderTest {
         PathDecoder stringDecoder = new PathDecoder();
 
         GResultOf<Path> result = stringDecoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -94,7 +95,7 @@ class PathDecoderTest {
         PathDecoder stringDecoder = new PathDecoder();
 
         GResultOf<Path> result = stringDecoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PatternDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/PatternDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -61,7 +62,7 @@ class PatternDecoderTest {
         PatternDecoder decoder = new PatternDecoder();
 
         GResultOf<Pattern> result = decoder.decode("db.user", Tags.of(), new LeafNode("test"),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -74,7 +75,7 @@ class PatternDecoderTest {
         PatternDecoder stringDecoder = new PatternDecoder();
 
         GResultOf<Pattern> result = stringDecoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -89,7 +90,7 @@ class PatternDecoderTest {
         PatternDecoder stringDecoder = new PatternDecoder();
 
         GResultOf<Pattern> result = stringDecoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -104,7 +105,7 @@ class PatternDecoderTest {
         PatternDecoder stringDecoder = new PatternDecoder();
 
         GResultOf<Pattern> result = stringDecoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderPassThroughTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderPassThroughTest.java
@@ -670,7 +670,7 @@ class ProxyDecoderPassThroughTest {
             } catch (UndeclaredThrowableException e) {
                 Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
                 Assertions.assertEquals("Failed to get pass through object from proxy config while calling method: getUri with " +
-                        "type: class java.lang.String in path: db.",
+                        "type: class java.lang.String in path: db",
                     e.getUndeclaredThrowable().getMessage());
             }
         } catch (GestaltException e) {
@@ -715,7 +715,7 @@ class ProxyDecoderPassThroughTest {
             } catch (UndeclaredThrowableException e) {
                 Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
                 Assertions.assertEquals("Failed to get pass through object from proxy config while calling method: getPort " +
-                        "with type: class java.lang.Integer in path: db.",
+                        "with type: class java.lang.Integer in path: db",
                     e.getUndeclaredThrowable().getMessage());
             }
         } catch (GestaltException e) {
@@ -760,7 +760,7 @@ class ProxyDecoderPassThroughTest {
             } catch (UndeclaredThrowableException e) {
                 Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
                 Assertions.assertEquals("Failed to get pass through object from proxy config while calling method: getPort with " +
-                        "type: int in path: db.",
+                        "type: int in path: db",
                     e.getUndeclaredThrowable().getMessage());
             }
         } catch (GestaltException e) {
@@ -805,7 +805,7 @@ class ProxyDecoderPassThroughTest {
             } catch (UndeclaredThrowableException e) {
                 Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
                 Assertions.assertEquals("Failed to get pass through object from proxy config while calling method: getPort with " +
-                        "type: class java.util.Optional in path: db.",
+                        "type: class java.util.Optional in path: db",
                     e.getUndeclaredThrowable().getMessage());
             }
         } catch (GestaltException e) {

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
@@ -93,7 +93,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -116,7 +116,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -146,7 +146,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -181,7 +181,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -224,7 +224,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -255,7 +255,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface2.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface2.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -293,7 +293,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -331,7 +331,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -361,7 +361,7 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -390,7 +390,7 @@ class ProxyDecoderTest {
         decoder.applyConfig(gestaltConfig);
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -409,7 +409,7 @@ class ProxyDecoderTest {
         decoder.applyConfig(gestaltConfig);
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), null,
-            TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -436,7 +436,7 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterface.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPoolInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -482,7 +482,7 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolGenericInterface.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPoolGenericInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -528,7 +528,7 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterfaceWrapper.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPoolInterfaceWrapper.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -579,7 +579,8 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterfaceDefault.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPoolInterfaceDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -619,7 +620,8 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterfaceDefaultGeneric.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(DBPoolInterfaceDefaultGeneric.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -654,7 +656,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(IDBInfoAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(IDBInfoAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -677,7 +680,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(IDBInfoAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(IDBInfoAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -707,7 +711,8 @@ class ProxyDecoderTest {
 
         GResultOf<Object> result =
             decoder.decode("db.host", Tags.of(), new MapNode(configs),
-                TypeCapture.of(IDBInfoBadAnnotations.class), new DecoderContext(decoderService, null, null));
+                TypeCapture.of(IDBInfoBadAnnotations.class),
+                new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -749,7 +754,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(IDBInfoAnnotationsLong.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(IDBInfoAnnotationsLong.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -772,7 +778,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(IDBInfoMethodAnnotations.class), new DecoderContext(decoderService, null, null));
+            new MapNode(configs), TypeCapture.of(IDBInfoMethodAnnotations.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ProxyDecoderTest.java
@@ -93,7 +93,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            TypeCapture.of(DBInfoInterfaceDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -116,7 +117,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -146,7 +148,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -181,7 +184,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -205,7 +209,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getUri " +
-                    "with type: class java.lang.String in path: db.host.",
+                    "with type: class java.lang.String in path: db.host",
                 e.getUndeclaredThrowable().getMessage());
         }
     }
@@ -224,7 +228,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceDefault.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -255,7 +260,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface2.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface2.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -275,7 +281,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getPort with " +
-                "type: class java.lang.Integer in path: db.host.", e.getUndeclaredThrowable().getMessage());
+                "type: class java.lang.Integer in path: db.host", e.getUndeclaredThrowable().getMessage());
         }
     }
 
@@ -293,7 +299,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterface.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -313,7 +320,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: " +
-                "getPort with type: int in path: db.host.", e.getUndeclaredThrowable().getMessage());
+                "getPort with type: int in path: db.host", e.getUndeclaredThrowable().getMessage());
         }
     }
 
@@ -331,7 +338,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -361,7 +369,8 @@ class ProxyDecoderTest {
         configs.put("password", new LeafNode("pass"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBInfoInterfaceOptional.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -390,7 +399,8 @@ class ProxyDecoderTest {
         decoder.applyConfig(gestaltConfig);
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new LeafNode("mysql.com"), TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -409,7 +419,8 @@ class ProxyDecoderTest {
         decoder.applyConfig(gestaltConfig);
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(), null,
-            TypeCapture.of(DBInfoNoConstructor.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            TypeCapture.of(DBInfoNoConstructor.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -436,7 +447,8 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBPoolInterface.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -460,7 +472,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getDefaultWait " +
-                    "with type: float in path: db.host.",
+                    "with type: float in path: db.host",
                 e.getUndeclaredThrowable().getMessage());
         }
     }
@@ -482,7 +494,8 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolGenericInterface.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBPoolGenericInterface.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -506,7 +519,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getDefaultWait " +
-                    "with type: float in path: db.host.",
+                    "with type: float in path: db.host",
                 e.getUndeclaredThrowable().getMessage());
         }
     }
@@ -528,7 +541,8 @@ class ProxyDecoderTest {
         configs.put("enabled", new LeafNode("true"));
 
         GResultOf<Object> result = decoder.decode("db.host", Tags.of(),
-            new MapNode(configs), TypeCapture.of(DBPoolInterfaceWrapper.class), new DecoderContext(decoderService, null, null, new PathLexer()));
+            new MapNode(configs), TypeCapture.of(DBPoolInterfaceWrapper.class),
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -557,7 +571,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.MISSING_VALUE, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getDefaultWait with type: " +
-                    "class java.lang.Float in path: db.host.",
+                    "class java.lang.Float in path: db.host",
                 e.getUndeclaredThrowable().getMessage());
         }
     }
@@ -735,7 +749,7 @@ class ProxyDecoderTest {
             Assertions.assertEquals(GestaltException.class, e.getUndeclaredThrowable().getClass());
             Assertions.assertEquals(ValidationLevel.ERROR, result.getErrors().get(0).level());
             Assertions.assertEquals("Failed to get cached object from proxy config while calling method: getPort " +
-                    "with type: int in path: db.host.",
+                    "with type: int in path: db.host",
                 e.getUndeclaredThrowable().getMessage());
         }
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/SetDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/SetDecoderTest.java
@@ -1,6 +1,7 @@
 package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.*;
 import org.github.gestalt.config.path.mapper.StandardPathMapper;
@@ -85,7 +86,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<Set<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -111,7 +112,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<HashSet<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -139,7 +140,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<TreeSet<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -167,7 +168,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<LinkedHashSet<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -199,7 +200,7 @@ class SetDecoderTest {
         // since I included all maps we pass in a List, this will not be found and will default to a
         // hashSet. In the real case it will not get called as the canDecode will return false
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -227,7 +228,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -253,7 +254,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -274,7 +275,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("0.1111, 0.22"), new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -292,7 +293,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode("a,b,c\\,d"), new TypeCapture<List<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -310,7 +311,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), new LeafNode(null), new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -325,7 +326,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), null, new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());
@@ -342,7 +343,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -355,7 +356,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -368,7 +369,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -388,7 +389,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -419,7 +420,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -442,7 +443,7 @@ class SetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("db.hosts", Tags.of(), new MapNode(new HashMap<>()), new TypeCapture<Set<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertTrue(values.hasErrors());
         Assertions.assertFalse(values.hasResults());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ShortDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/ShortDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -64,7 +65,7 @@ class ShortDecoderTest {
         ShortDecoder decoder = new ShortDecoder();
 
         GResultOf<Short> result = decoder.decode("db.port", Tags.of(), new LeafNode("124"),
-            TypeCapture.of(Short.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Short.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals((short) 124, (short) result.results());
@@ -76,7 +77,7 @@ class ShortDecoderTest {
         ShortDecoder decoder = new ShortDecoder();
 
         GResultOf<Short> result = decoder.decode("db.port", Tags.of(), new LeafNode("12s4"),
-            TypeCapture.of(Short.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Short.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -93,7 +94,7 @@ class ShortDecoderTest {
 
         GResultOf<Short> result = decoder.decode("db.port", Tags.of(),
             new LeafNode("12345678901234567890123456789012345678901234567890123456789"), TypeCapture.of(Short.class),
-            new DecoderContext(decoderService, null, null));
+            new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/StringAndLeafDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/StringAndLeafDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -60,7 +61,7 @@ class StringAndLeafDecoderTest {
         StringDecoder stringDecoder = new StringDecoder();
 
         GResultOf<String> result = stringDecoder.decode("db.user", Tags.of(), new LeafNode("test"),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals("test", result.results());
@@ -72,7 +73,7 @@ class StringAndLeafDecoderTest {
         StringDecoder stringDecoder = new StringDecoder();
 
         GResultOf<String> result = stringDecoder.decode("db.user", Tags.of(), new LeafNode(null),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -87,7 +88,7 @@ class StringAndLeafDecoderTest {
         StringDecoder stringDecoder = new StringDecoder();
 
         GResultOf<String> result = stringDecoder.decode("db.user", Tags.of(), null,
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());
@@ -102,7 +103,7 @@ class StringAndLeafDecoderTest {
         StringDecoder stringDecoder = new StringDecoder();
 
         GResultOf<String> result = stringDecoder.decode("db.user", Tags.of(), new MapNode(new HashMap<>()),
-            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(String.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/URIDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/URIDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -69,7 +70,7 @@ class URIDecoderTest {
 
         String uri = "http://www.google.com";
         GResultOf<URI> result = decoder.decode("db.port", Tags.of(), new LeafNode(uri),
-            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(uri, result.results().toString());
@@ -82,7 +83,7 @@ class URIDecoderTest {
 
         String uri = "http://www.google.com[]";
         GResultOf<URI> result = decoder.decode("db.port", Tags.of(), new LeafNode(uri),
-            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/URLDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/URLDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -71,7 +72,7 @@ class URLDecoderTest {
 
         String url = "http://www.google.com";
         GResultOf<URL> result = decoder.decode("db.port", Tags.of(), new LeafNode(url),
-            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(url, result.results().toString());
@@ -84,7 +85,7 @@ class URLDecoderTest {
 
         String uri = "8080:www.google.com";
         GResultOf<URL> result = decoder.decode("db.port", Tags.of(), new LeafNode(uri),
-            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(URI.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/UUIDDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/UUIDDecoderTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config.decoder;
 
 import org.github.gestalt.config.entity.ValidationLevel;
 import org.github.gestalt.config.exceptions.GestaltConfigurationException;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.node.ConfigNodeService;
 import org.github.gestalt.config.node.LeafNode;
@@ -67,7 +68,7 @@ class UUIDDecoderTest {
 
         UUID uuid = UUID.randomUUID();
         GResultOf<UUID> result = decoder.decode("db.port", Tags.of(), new LeafNode(uuid.toString()),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
         Assertions.assertEquals(uuid, result.results());
@@ -80,7 +81,7 @@ class UUIDDecoderTest {
 
 
         GResultOf<UUID> result = decoder.decode("db.port", Tags.of(), new LeafNode("asdfasdfsdf"),
-            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null));
+            TypeCapture.of(Long.class), new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
         Assertions.assertNull(result.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
@@ -12,6 +12,21 @@ public class NoResultSentenceLexer extends SentenceLexer {
     }
 
     @Override
+    public String getNormalizedArrayOpenTag() {
+        return "";
+    }
+
+    @Override
+    public String getNormalizedArrayCloseTag() {
+        return "";
+    }
+
+    @Override
+    public String getNormalizedMapTag() {
+        return "";
+    }
+
+    @Override
     public String getDeliminator() {
         return "";
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
@@ -7,8 +7,13 @@ import java.util.List;
 
 public class NoResultSentenceLexer extends SentenceLexer {
     @Override
-    public String getDeliminator() {
+    public String getNormalizedDeliminator() {
         return null;
+    }
+
+    @Override
+    public String getDeliminator() {
+        return "";
     }
 
     @Override

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/NoResultSentenceLexer.java
@@ -32,7 +32,7 @@ public class NoResultSentenceLexer extends SentenceLexer {
     }
 
     @Override
-    protected List<String> tokenizer(String sentence) {
+    public List<String> tokenizer(String sentence) {
         return null;
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/PathLexerBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/PathLexerBuilderTest.java
@@ -1,0 +1,28 @@
+package org.github.gestalt.config.lexer;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PathLexerBuilderTest {
+
+    @Test
+    public void testBuilder() {
+
+        PathLexerBuilder builder = PathLexerBuilder.builder()
+            .setDelimiter("*")
+            .setNormalizedDelimiter("_")
+            .setNormalizedArrayOpenTag("{")
+            .setNormalizedArrayCloseTag("}")
+            .setNormalizedMapTag(":")
+            .setSentenceNormalizer(new LowerCaseSentenceNormalizer())
+            .setPathPatternRegex("ABC");
+
+        var lexer = builder.build();
+        Assertions.assertEquals("*", lexer.getDeliminator());
+        Assertions.assertEquals("_", lexer.getNormalizedDeliminator());
+        Assertions.assertEquals("{", lexer.getNormalizedArrayOpenTag());
+        Assertions.assertEquals("}", lexer.getNormalizedArrayCloseTag());
+        Assertions.assertEquals(":", lexer.getNormalizedMapTag());
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/lexer/PathLexerTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/lexer/PathLexerTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.github.gestalt.config.lexer.PathLexer.DEFAULT_EVALUATOR;
+
 class PathLexerTest {
 
     @Test
@@ -319,5 +321,21 @@ class PathLexerTest {
 
         List<Token> tokens = result.results();
         Assertions.assertEquals(1, tokens.size());
+    }
+
+    @Test
+    public void testTokenizerFullConstructor() {
+        PathLexer pathLexer = new PathLexer(".", "_", DEFAULT_EVALUATOR, new LowerCaseSentenceNormalizer());
+
+        List<String> result = pathLexer.tokenizer("the_quick[]_brown_fox");
+
+        Assertions.assertEquals(".", pathLexer.getNormalizedDeliminator());
+        Assertions.assertEquals("_", pathLexer.getDeliminator());
+
+        Assertions.assertEquals(4, result.size());
+        Assertions.assertEquals("the", result.get(0));
+        Assertions.assertEquals("quick[]", result.get(1));
+        Assertions.assertEquals("brown", result.get(2));
+        Assertions.assertEquals("fox", result.get(3));
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/EnvironmentLoaderTest.java
@@ -56,7 +56,7 @@ class EnvironmentLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -81,7 +81,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -117,7 +117,7 @@ class EnvironmentLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -142,7 +142,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -179,7 +179,7 @@ class EnvironmentLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -211,7 +211,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(true));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(true));
     }
 
     @Test
@@ -230,7 +230,7 @@ class EnvironmentLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), anyBoolean())).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), anyBoolean())).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -272,7 +272,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(any(), anyBoolean());
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), any(), anyBoolean());
 
     }
 
@@ -293,7 +293,7 @@ class EnvironmentLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.errors(new ValidationError.EmptyPath()));
         Mockito.when(lexer.scan("db.name"))
@@ -318,7 +318,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(1, argument.getValue().size());
@@ -359,7 +359,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
 
     }
 
@@ -387,7 +387,7 @@ class EnvironmentLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapConfigLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/MapConfigLoaderTest.java
@@ -54,7 +54,7 @@ class MapConfigLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -78,7 +78,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -114,7 +114,7 @@ class MapConfigLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -138,7 +138,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -175,7 +175,7 @@ class MapConfigLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -203,7 +203,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), any(), eq(false));
     }
 
     @Test
@@ -222,7 +222,7 @@ class MapConfigLoaderTest {
         ConfigSource source = Mockito.mock(ConfigSource.class);
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.errors(new ValidationError.EmptyPath()));
         Mockito.when(lexer.scan("db.name"))
@@ -246,7 +246,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(1, argument.getValue().size());
@@ -289,7 +289,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
 
     }
 
@@ -319,7 +319,7 @@ class MapConfigLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
@@ -55,7 +55,7 @@ class PropertyLoaderTest {
         ConfigNode node = new LeafNode("test");
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -79,7 +79,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -114,7 +114,7 @@ class PropertyLoaderTest {
         ConfigNode node = new LeafNode("test");
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -138,7 +138,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(2, argument.getValue().size());
@@ -174,7 +174,7 @@ class PropertyLoaderTest {
         ConfigNode node = new LeafNode("test");
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.result(Collections.singletonList(new ObjectToken("test"))));
         Mockito.when(lexer.scan("db.name"))
@@ -200,7 +200,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), any(), eq(false));
     }
 
     @Test
@@ -218,7 +218,7 @@ class PropertyLoaderTest {
         ConfigNode node = new LeafNode("test");
 
         // mock the interactions with the parser and lexer
-        Mockito.when(parser.parse(anyList(), eq(false))).thenReturn(GResultOf.result(node));
+        Mockito.when(parser.parse(any(), anyList(), eq(false))).thenReturn(GResultOf.result(node));
         Mockito.when(lexer.scan("test"))
             .thenReturn(GResultOf.errors(new ValidationError.EmptyPath()));
         Mockito.when(lexer.scan("db.name"))
@@ -242,7 +242,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(2)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(1)).parse(argument.capture(), eq(false));
+        Mockito.verify(parser, Mockito.times(1)).parse(any(), argument.capture(), eq(false));
 
         // result the parser was sent the correct arguments.
         Assertions.assertEquals(1, argument.getValue().size());
@@ -286,7 +286,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
 
     }
 
@@ -316,7 +316,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
     }
 
     @Test
@@ -345,7 +345,7 @@ class PropertyLoaderTest {
 
         // verify we get the correct number of calls and capture the parsers arguments.
         Mockito.verify(lexer, Mockito.times(0)).scan(anyString());
-        Mockito.verify(parser, Mockito.times(0)).parse(any(), eq(false));
+        Mockito.verify(parser, Mockito.times(0)).parse(any(), any(), eq(false));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeManagerTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeManagerTest.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.node;
 import org.github.gestalt.config.entity.ConfigNodeContainer;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.post.process.PostProcessor;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.github.gestalt.config.source.ConfigSource;
@@ -2165,7 +2166,7 @@ class ConfigNodeManagerTest {
         }
 
         @Override
-        public String printer(String path, SecretConcealer secretConcealer) {
+        public String printer(String path, SecretConcealer secretConcealer, SentenceLexer lexer) {
             return null;
         }
     }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/node/ConfigNodeTest.java
@@ -1,5 +1,6 @@
 package org.github.gestalt.config.node;
 
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.secret.rules.SecretConcealer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -160,10 +161,10 @@ class ConfigNodeTest {
         LeafNode leaf = new LeafNode("leaf");
 
         Assertions.assertEquals("ArrayNode{values=[LeafNode{value='a'}, LeafNode{value='b'}]}",
-            arrayNode.printer("", null));
+            arrayNode.printer("", null, new PathLexer()));
         Assertions.assertEquals("MapNode{test2=LeafNode{value='leaf2'}, test=LeafNode{value='leaf'}}",
-            objectNode.printer("", null));
-        Assertions.assertEquals("LeafNode{value='leaf'}", leaf.printer("", null));
+            objectNode.printer("", null, new PathLexer()));
+        Assertions.assertEquals("LeafNode{value='leaf'}", leaf.printer("", null, new PathLexer()));
     }
 
     @Test
@@ -176,7 +177,20 @@ class ConfigNodeTest {
 
         Assertions.assertEquals("MapNode{test2=ArrayNode{values=[LeafNode{value='a'}, LeafNode{value='b'}]}, " +
                 "test=LeafNode{value='leaf'}}",
-            objectNode.printer("", null));
+            objectNode.printer("", null, new PathLexer()));
+    }
+
+    @Test
+    void printerComplexTestCustomDelimiter() {
+        ArrayNode arrayNode = new ArrayNode(List.of(new LeafNode("a"), new LeafNode("b")));
+        Map<String, ConfigNode> mapNode = new HashMap<>();
+        mapNode.put("test", new LeafNode("leaf"));
+        mapNode.put("test2", arrayNode);
+        MapNode objectNode = new MapNode(mapNode);
+
+        Assertions.assertEquals("MapNode{test2=ArrayNode{values=[LeafNode{value='a'}, LeafNode{value='b'}]}, " +
+                "test=LeafNode{value='leaf'}}",
+            objectNode.printer("", null, new PathLexer("_")));
     }
 
     @Test
@@ -189,7 +203,7 @@ class ConfigNodeTest {
 
         Assertions.assertEquals("MapNode{abc=LeafNode{value='*****'}, def=ArrayNode{values=[LeafNode{value='a'}, " +
                 "LeafNode{value='b'}]}}",
-            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****")));
+            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****"), new PathLexer()));
     }
 
     @Test
@@ -202,7 +216,7 @@ class ConfigNodeTest {
 
         Assertions.assertEquals("MapNode{abc=LeafNode{value='*****'}, def=ArrayNode{values=[LeafNode{value='a'}, " +
                 "LeafNode{value='b'}]}}",
-            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****")));
+            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****"), new PathLexer()));
     }
 
     @Test
@@ -214,7 +228,7 @@ class ConfigNodeTest {
         MapNode objectNode = new MapNode(mapNode);
 
         Assertions.assertEquals("MapNode{abc='null', def=ArrayNode{values=[LeafNode{value='a'}, LeafNode{value='b'}]}}",
-            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****")));
+            objectNode.printer("", new SecretConcealer(Set.of("abc"), "*****"), new PathLexer()));
     }
 
     @Test
@@ -228,7 +242,7 @@ class ConfigNodeTest {
 
         Assertions.assertEquals("MapNode{abc=LeafNode{value='null'}, def=ArrayNode{values=[LeafNode{value='a'}, " +
                 "LeafNode{value='b'}, LeafNode{value='null'}]}, hij='null'}",
-            objectNode.printer("", new SecretConcealer(Set.of("aaa"), "*****")));
+            objectNode.printer("", new SecretConcealer(Set.of("aaa"), "*****"), new PathLexer()));
     }
 }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/parser/MapConfigParserTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/parser/MapConfigParserTest.java
@@ -3,6 +3,7 @@ package org.github.gestalt.config.parser;
 import org.github.gestalt.config.entity.ConfigValue;
 import org.github.gestalt.config.entity.ValidationError;
 import org.github.gestalt.config.entity.ValidationLevel;
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.node.ConfigNode;
 import org.github.gestalt.config.token.ArrayToken;
 import org.github.gestalt.config.token.ObjectToken;
@@ -34,7 +35,7 @@ class MapConfigParserTest {
     }
 
     @Test
-    public void testBuildConfigTree() {
+    public void testbuildConfigTree() {
         MapConfigParser mapConfigParser = new MapConfigParser();
 
         List<Pair<List<Token>, ConfigValue>> test = List.of(
@@ -46,7 +47,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("20"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.parse(test, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.parse(new PathLexer(), test, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -73,7 +74,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("20"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -96,7 +97,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("11"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -133,7 +134,7 @@ class MapConfigParserTest {
                 new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("101"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -186,7 +187,7 @@ class MapConfigParserTest {
                 new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("101"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -222,7 +223,7 @@ class MapConfigParserTest {
                 new ObjectToken("db"), new ObjectToken("hosts"), new ArrayToken(0), new ObjectToken("name")), new ConfigValue("host1"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertFalse(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -239,7 +240,7 @@ class MapConfigParserTest {
     public void testValidateNullTokens() {
         MapConfigParser mapConfigParser = new MapConfigParser();
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(null, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), null, 0, false);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -262,7 +263,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ObjectToken("name")), new ConfigValue("hostDB"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -288,7 +289,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ObjectToken("name")), new ConfigValue("hostDB"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -315,7 +316,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ObjectToken("name")), new ConfigValue("hostDB2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -338,7 +339,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts")), new ConfigValue("hostDB2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -361,7 +362,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ObjectToken("name")), new ConfigValue("hostDB2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -386,7 +387,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ObjectToken("name")), new ConfigValue("hostDB2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -409,7 +410,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ArrayToken(-1)), new ConfigValue("host2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
 
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
@@ -432,7 +433,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("db"), new ObjectToken("hosts"), new ArrayToken(0)), new ConfigValue("host2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -455,7 +456,7 @@ class MapConfigParserTest {
                 new ConfigValue("hostDB2"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -479,7 +480,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("10"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, false);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, false);
         assertTrue(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNotNull(resultsOf.results());
@@ -524,7 +525,7 @@ class MapConfigParserTest {
                 new ObjectToken("redis"), new ObjectToken("port")), new ConfigValue("10"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -545,7 +546,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("admin"), new ArrayToken(1)), new ConfigValue("Gary"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());
@@ -566,7 +567,7 @@ class MapConfigParserTest {
             new Pair<>(List.of(new ObjectToken("redis"), new OtherToken()), new ConfigValue("10"))
         );
 
-        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(test, 0, true);
+        GResultOf<ConfigNode> resultsOf = mapConfigParser.buildConfigTree(new PathLexer(), test, 0, true);
         assertFalse(resultsOf.hasResults());
         assertTrue(resultsOf.hasErrors());
         assertNull(resultsOf.results());

--- a/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
@@ -1,5 +1,6 @@
 package org.github.gestalt.config.utils;
 
+import org.github.gestalt.config.lexer.PathLexer;
 import org.github.gestalt.config.token.ArrayToken;
 import org.github.gestalt.config.token.ObjectToken;
 import org.github.gestalt.config.token.TagToken;
@@ -14,14 +15,21 @@ class PathUtilTest {
     @Test
     void toPath() {
         List<Token> tokens = List.of(new ObjectToken("obj"), new ArrayToken(1), new TagToken("tag", "value"));
-        Assertions.assertEquals("obj[1]tag=value", PathUtil.toPath(tokens));
+        Assertions.assertEquals("obj[1]tag=value", PathUtil.toPath(new PathLexer(), tokens));
     }
 
     @Test
     void pathForKey() {
-        Assertions.assertEquals("my.path.test", PathUtil.pathForKey("my.path", "test"));
-        Assertions.assertEquals("test", PathUtil.pathForKey("", "test"));
-        Assertions.assertEquals("test", PathUtil.pathForKey(null, "test"));
+        Assertions.assertEquals("my.path.test", PathUtil.pathForKey(new PathLexer(), "my.path", "test"));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), "", "test"));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), null, "test"));
+    }
+
+    @Test
+    void pathForKeyCustomNormalizer() {
+        Assertions.assertEquals("my_path_test", PathUtil.pathForKey(new PathLexer("_"), "my_path", "test"));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), "", "test"));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), null, "test"));
     }
 
     @Test

--- a/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
@@ -38,4 +38,11 @@ class PathUtilTest {
         Assertions.assertEquals("[0]", PathUtil.pathForIndex(new PathLexer(), "", 0));
         Assertions.assertEquals("[0]", PathUtil.pathForIndex(new PathLexer(), null, 0));
     }
+
+    @Test
+    void pathForIndexArray() {
+        Assertions.assertEquals("my.path.test", PathUtil.pathForKey(new PathLexer(), "", List.of("my", "path", "test")));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), "", List.of("test")));
+        Assertions.assertEquals("test", PathUtil.pathForKey(new PathLexer(), null, List.of("test")));
+    }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/utils/PathUtilTest.java
@@ -34,8 +34,8 @@ class PathUtilTest {
 
     @Test
     void pathForIndex() {
-        Assertions.assertEquals("my.path[0]", PathUtil.pathForIndex("my.path", 0));
-        Assertions.assertEquals("[0]", PathUtil.pathForIndex("", 0));
-        Assertions.assertEquals("[0]", PathUtil.pathForIndex(null, 0));
+        Assertions.assertEquals("my.path[0]", PathUtil.pathForIndex(new PathLexer(), "my.path", 0));
+        Assertions.assertEquals("[0]", PathUtil.pathForIndex(new PathLexer(), "", 0));
+        Assertions.assertEquals("[0]", PathUtil.pathForIndex(new PathLexer(), null, 0));
     }
 }

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
@@ -151,7 +151,7 @@ public final class HoconLoader implements ConfigLoader {
         List<ConfigNode> array = new ArrayList<>();
         AtomicInteger index = new AtomicInteger(0);
         configList.forEach(it -> {
-            String currentPath = PathUtil.pathForIndex(path, index.getAndIncrement());
+            String currentPath = PathUtil.pathForIndex(lexer, path, index.getAndIncrement());
 
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, it);
             errors.addAll(node.getErrors());

--- a/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
+++ b/gestalt-hocon/src/main/java/org/github/gestalt/config/hocon/HoconLoader.java
@@ -171,7 +171,7 @@ public final class HoconLoader implements ConfigLoader {
 
         configObject.forEach((key, value) -> {
             String newPath = normalizeSentence(key);
-            String currentPath = PathUtil.pathForKey(path, key);
+            String currentPath = PathUtil.pathForKey(lexer, path, key);
 
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, value);
             errors.addAll(node.getErrors());

--- a/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconLoaderTest.java
+++ b/gestalt-hocon/src/test/java/org/github/gestalt/config/hocon/HoconLoaderTest.java
@@ -69,6 +69,42 @@ class HoconLoaderTest {
     }
 
     @Test
+    void loadSourceLexedMultiPath() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("{\n" +
+            "  \"user.name\":\"Steve\",\n" +
+            "  \"age\":42,\n" +
+            "  \"cars\": [\n" +
+            "    { \"name\":\"Ford\", \"models\":[ \"Fiesta\", \"Focus\", \"Mustang\" ] },\n" +
+            "    { \"name\":\"BMW\", \"models\":[ \"320\", \"X3\", \"X5\" ] },\n" +
+            "    { \"name\":\"Fiat\", \"models\":[ \"500\", \"Panda\" ] }\n" +
+            "  ]\n" +
+            " } ", "conf");
+
+        HoconLoader hoconLoader = new HoconLoader();
+
+        var resultContainer = hoconLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals("Steve", result.getKey("user").get().getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceModuleConfig() throws GestaltException {
 
         StringConfigSource source = new StringConfigSource("{\n" +

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
@@ -153,7 +153,7 @@ public final class JsonLoader implements ConfigLoader {
         List<ConfigNode> array = new ArrayList<>();
         int arraySize = jsonNode.size();
         for (int i = 0; i < arraySize; i++) {
-            String currentPath = PathUtil.pathForIndex(path, i);
+            String currentPath = PathUtil.pathForIndex(lexer, path, i);
 
             JsonNode arrayNodes = jsonNode.get(i);
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, arrayNodes);

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
@@ -148,6 +148,10 @@ public final class JsonLoader implements ConfigLoader {
         return lexer.normalizeSentence(sentence);
     }
 
+    private List<String> tokenizer(String sentence) {
+        return lexer.tokenizer(sentence);
+    }
+
     private GResultOf<ConfigNode> buildArrayConfigTree(String path, JsonNode jsonNode) {
         List<ValidationError> errors = new ArrayList<>();
         List<ConfigNode> array = new ArrayList<>();
@@ -175,16 +179,23 @@ public final class JsonLoader implements ConfigLoader {
         for (Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
             Map.Entry<String, JsonNode> entry = it.next();
             String key = normalizeSentence(entry.getKey());
+            List<String> tokenList = tokenizer(key);
+            String currentPath = PathUtil.pathForKey(lexer, path, tokenList);
+
             JsonNode jsonValue = entry.getValue();
-
-            String currentPath = PathUtil.pathForKey(lexer, path, key);
-
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, jsonValue);
             errors.addAll(node.getErrors());
             if (!node.hasResults()) {
                 errors.add(new ValidationError.NoResultsFoundForPath(currentPath));
             } else {
-                mapNode.put(key, node.results());
+                ConfigNode currentNode = node.results();
+                for (int i = tokenList.size() - 1; i > 0; i--) {
+                    Map<String, ConfigNode> nextMapNode = new HashMap<>();
+                    nextMapNode.put(tokenList.get(i), currentNode);
+                    currentNode = new MapNode(nextMapNode);
+                }
+
+                mapNode.put(tokenList.get(0), currentNode);
             }
         }
 

--- a/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
+++ b/gestalt-json/src/main/java/org/github/gestalt/config/json/JsonLoader.java
@@ -177,7 +177,7 @@ public final class JsonLoader implements ConfigLoader {
             String key = normalizeSentence(entry.getKey());
             JsonNode jsonValue = entry.getValue();
 
-            String currentPath = PathUtil.pathForKey(path, key);
+            String currentPath = PathUtil.pathForKey(lexer, path, key);
 
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, jsonValue);
             errors.addAll(node.getErrors());

--- a/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
+++ b/gestalt-json/src/test/java/org/github/gestalt/config/json/JsonLoaderTest.java
@@ -74,6 +74,46 @@ class JsonLoaderTest {
     }
 
     @Test
+    void loadSourceLexedMiltiPath() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("{\n" +
+            "  \"user.name\":\"Steve\",\n" +
+            "  \"age\":42,\n" +
+            "  \"cars\": [\n" +
+            "    { \"name\":\"Ford\", \"models\":[ \"Fiesta\", \"Focus\", \"Mustang\" ] },\n" +
+            "    { \"name\":\"BMW\", \"models\":[ \"320\", \"X3\", \"X5\" ] },\n" +
+            "    { \"name\":\"Fiat\", \"models\":[ \"500\", \"Panda\" ] }\n" +
+            "  ]\n" +
+            " } ", "json");
+
+        JsonLoader jsonLoader = new JsonLoader();
+        GestaltConfig config = new GestaltConfig();
+        config.setSentenceLexer(new PathLexer());
+
+        jsonLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = jsonLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+
+        Assertions.assertEquals(Tags.of(), resultContainer.results().get(0).getTags());
+        Assertions.assertEquals("Steve", result.getKey("user").get().getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceModuleConfig() throws GestaltException {
 
         StringConfigSource source = new StringConfigSource("{\n" +

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoder.kt
@@ -47,7 +47,7 @@ class ByteDecoder : LeafDecoder<Byte>() {
                 ValidationError.DecodingByteTooLong(
                     path,
                     node,
-                    decoderContext.secretConcealer
+                    decoderContext
                 )
             )
         } else {
@@ -55,7 +55,7 @@ class ByteDecoder : LeafDecoder<Byte>() {
                 ValidationError.DecodingEmptyByte(
                     path,
                     node,
-                    decoderContext.secretConcealer
+                    decoderContext
                 )
             )
         }

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoder.kt
@@ -44,7 +44,7 @@ class CharDecoder : LeafDecoder<Char>() {
             results = value[0]
         }
         if (value.length != 1) {
-            error.add(ValidationError.DecodingCharWrongSize(path, node, decoderContext.secretConcealer))
+            error.add(ValidationError.DecodingCharWrongSize(path, node, decoderContext))
         }
         return GResultOf.resultOf(results, error)
     }

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoder.kt
@@ -67,7 +67,6 @@ class DataClassDecoder : Decoder<Any> {
         }
 
         val decoderService = decoderContext.decoderService
-        val secretConceal = decoderContext.secretConcealer
 
         if (type is KTypeCapture<*>) {
             val classifier = type.kType.classifier
@@ -92,7 +91,7 @@ class DataClassDecoder : Decoder<Any> {
                         if (configAnnotation?.path?.isNotEmpty() == true) {
                             paramName = configAnnotation.path
                         }
-                        val nextPath = PathUtil.pathForKey(path, paramName)
+                        val nextPath = PathUtil.pathForKey(decoderContext.getDefaultLexer(), path, paramName)
 
                         val configNode = decoderService.getNextNode(nextPath, paramName, node)
                         errors.addAll(configNode.getErrorsNotLevel(ValidationLevel.MISSING_VALUE))
@@ -132,7 +131,7 @@ class DataClassDecoder : Decoder<Any> {
                                 if (defaultGResultOf.hasResults()) {
                                     resultValid = true
                                     results = defaultGResultOf.results()
-                                    errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, secretConceal))
+                                    errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, decoderContext))
                                 } else {
                                     missingMembers.add(it.name ?: "null")
                                 }
@@ -141,7 +140,7 @@ class DataClassDecoder : Decoder<Any> {
                             // if the type is nullable, it is an optional value.
                             it.type.isMarkedNullable -> {
                                 resultValid = true
-                                errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, secretConceal))
+                                errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, decoderContext))
                             }
 
                             // if we dont have results for the config node, and the value is not optional
@@ -151,7 +150,7 @@ class DataClassDecoder : Decoder<Any> {
 
                             // if we dont have results for the config node, and the value is optional
                             it.isOptional -> {
-                                errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, secretConceal))
+                                errors.add(OptionalMissingValueDecoding(nextPath, node, name(), type.rawType.simpleName, decoderContext))
                             }
 
                         }

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoder.kt
@@ -45,7 +45,7 @@ class DoubleDecoder : LeafDecoder<Double>() {
                 val longVal = value.toDouble()
                 GResultOf.result(longVal)
             } catch (e: NumberFormatException) {
-                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.secretConcealer))
+                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext))
             }
         } else {
             GResultOf.errors(ValidationError.DecodingNumberParsing(path, node, name()))

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoder.kt
@@ -45,7 +45,7 @@ class FloatDecoder : LeafDecoder<Float>() {
                 val floatVal = value.toFloat()
                 GResultOf.result(floatVal)
             } catch (e: NumberFormatException) {
-                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.secretConcealer))
+                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext))
             }
         } else {
             GResultOf.errors(ValidationError.DecodingNumberParsing(path, node, name()))

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoder.kt
@@ -45,7 +45,7 @@ class IntegerDecoder : LeafDecoder<Int>() {
                 val intVal = value.toInt()
                 GResultOf.result(intVal)
             } catch (e: NumberFormatException) {
-                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.secretConcealer))
+                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext))
             }
         } else {
             GResultOf.errors(ValidationError.DecodingNumberParsing(path, node, name()))

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoder.kt
@@ -45,7 +45,7 @@ class LongDecoder : LeafDecoder<Long>() {
                 val longVal = value.toLong()
                 GResultOf.result(longVal)
             } catch (e: NumberFormatException) {
-                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.secretConcealer))
+                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext))
             }
         } else {
             GResultOf.errors(ValidationError.DecodingNumberParsing(path, node, name()))

--- a/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoder.kt
+++ b/gestalt-kotlin/src/main/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoder.kt
@@ -45,7 +45,7 @@ class ShortDecoder : LeafDecoder<Short>() {
                 val intVal = value.toShort()
                 GResultOf.result(intVal)
             } catch (e: NumberFormatException) {
-                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext.secretConcealer))
+                GResultOf.errors(ValidationError.DecodingNumberFormatException(path, node, name(), decoderContext))
             }
         } else {
             GResultOf.errors(ValidationError.DecodingNumberParsing(path, node, name()))

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/BooleanDecoderTest.kt
@@ -6,6 +6,7 @@ import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.KTypeCapture
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -68,7 +69,7 @@ internal class BooleanDecoderTest {
             TypeCapture.of(
                 Int::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -85,7 +86,7 @@ internal class BooleanDecoderTest {
             TypeCapture.of(
                 Int::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -102,7 +103,7 @@ internal class BooleanDecoderTest {
             TypeCapture.of(
                 Int::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ByteDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -65,7 +66,7 @@ internal class ByteDecoderTest {
             TypeCapture.of(
                 Byte::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -83,7 +84,7 @@ internal class ByteDecoderTest {
             TypeCapture.of(
                 Byte::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -106,7 +107,7 @@ internal class ByteDecoderTest {
             TypeCapture.of(
                 Byte::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/CharDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class CharDecoderTest {
             TypeCapture.of(
                 Char::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -82,7 +83,7 @@ internal class CharDecoderTest {
             TypeCapture.of(
                 Char::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -105,7 +106,7 @@ internal class CharDecoderTest {
             TypeCapture.of(
                 Char::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DataClassDecoderTest.kt
@@ -74,7 +74,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -93,7 +93,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             configs,
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -115,7 +115,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             TypeCapture.of(DBInfo::class.java),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -136,7 +136,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -165,7 +165,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoRequired>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -184,7 +184,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -207,7 +207,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoNoDefaultOptional>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -237,7 +237,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoNullable>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -267,7 +267,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoNoDefault>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -292,7 +292,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -323,7 +323,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoRequired>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -353,7 +353,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfo>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -384,7 +384,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoAnnotation>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -406,7 +406,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoAnnotation>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -436,7 +436,7 @@ class DataClassDecoderTest {
             "db.host", Tags.of(),
             MapNode(configs),
             kTypeCaptureOf<DBInfoAnnotationLong>(),
-            DecoderContext(decoderService, null, null)
+            DecoderContext(decoderService, null, null, PathLexer())
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/DoubleDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class DoubleDecoderTest {
             TypeCapture.of(
                 Double::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -80,7 +81,7 @@ internal class DoubleDecoderTest {
             "db.port", Tags.of(),
             LeafNode("124.5"),
             object : TypeCapture<Double?>() {},
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -98,7 +99,7 @@ internal class DoubleDecoderTest {
             TypeCapture.of(
                 Double::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -116,7 +117,7 @@ internal class DoubleDecoderTest {
             TypeCapture.of(
                 Double::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/FloatDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class FloatDecoderTest {
             TypeCapture.of(
                 Float::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -82,7 +83,7 @@ internal class FloatDecoderTest {
             TypeCapture.of(
                 Float::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -100,7 +101,7 @@ internal class FloatDecoderTest {
             TypeCapture.of(
                 Float::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/IntegerDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -63,7 +64,7 @@ internal class IntegerDecoderTest {
             TypeCapture.of(
                 Int::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -81,7 +82,7 @@ internal class IntegerDecoderTest {
             TypeCapture.of(
                 Int::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -103,7 +104,7 @@ internal class IntegerDecoderTest {
             "db.port", Tags.of(),
             LeafNode("12345678901234567890123456789012345678901234567890123456789"),
             TypeCapture.of(Int::class.java),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/LongDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class LongDecoderTest {
             TypeCapture.of(
                 Long::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -82,7 +83,7 @@ internal class LongDecoderTest {
             TypeCapture.of(
                 Long::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -104,7 +105,7 @@ internal class LongDecoderTest {
             "db.port", Tags.of(),
             LeafNode("12345678901234567890123456789012345678901234567890123456"),
             TypeCapture.of(Long::class.java),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/ShortDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class ShortDecoderTest {
             TypeCapture.of(
                 Short::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -82,7 +83,7 @@ internal class ShortDecoderTest {
             TypeCapture.of(
                 Short::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -104,7 +105,7 @@ internal class ShortDecoderTest {
             "db.port", Tags.of(),
             LeafNode("12345678901234567890123456789012345678901234567890123456789"),
             TypeCapture.of(Short::class.java),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/StringAndLeafDecoderTest.kt
+++ b/gestalt-kotlin/src/test/kotlin/org/github/gestalt/config/kotlin/decoder/StringAndLeafDecoderTest.kt
@@ -5,6 +5,7 @@ import org.github.gestalt.config.decoder.DecoderRegistry
 import org.github.gestalt.config.entity.ValidationLevel
 import org.github.gestalt.config.exceptions.GestaltException
 import org.github.gestalt.config.kotlin.reflect.kTypeCaptureOf
+import org.github.gestalt.config.lexer.PathLexer
 import org.github.gestalt.config.lexer.SentenceLexer
 import org.github.gestalt.config.node.ConfigNodeService
 import org.github.gestalt.config.node.LeafNode
@@ -64,7 +65,7 @@ internal class StringAndLeafDecoderTest {
             TypeCapture.of(
                 String::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertTrue(result.hasResults())
         Assertions.assertFalse(result.hasErrors())
@@ -82,7 +83,7 @@ internal class StringAndLeafDecoderTest {
             TypeCapture.of(
                 String::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())
@@ -105,7 +106,7 @@ internal class StringAndLeafDecoderTest {
             TypeCapture.of(
                 String::class.java
             ),
-            DecoderContext(decoderService, null, null),
+            DecoderContext(decoderService, null, null, PathLexer()),
         )
         Assertions.assertFalse(result.hasResults())
         Assertions.assertTrue(result.hasErrors())

--- a/gestalt-test/src/test/java/org/github/gestalt/config/decoder/RecordDecoderTest.java
+++ b/gestalt-test/src/test/java/org/github/gestalt/config/decoder/RecordDecoderTest.java
@@ -75,7 +75,7 @@ class RecordDecoderTest {
         configs.put("id", new LeafNode("52"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -93,7 +93,7 @@ class RecordDecoderTest {
         configs.put("name", new LeafNode("tim"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -111,7 +111,7 @@ class RecordDecoderTest {
         configs.put("id", new LeafNode("52"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person2.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -131,7 +131,7 @@ class RecordDecoderTest {
         configs.put("phone", new LeafNode("12345"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -151,7 +151,7 @@ class RecordDecoderTest {
         configs.put("phone", new LeafNode("12345"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -177,7 +177,7 @@ class RecordDecoderTest {
         configs.put("phone", new LeafNode("12345"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(Person.class),
-            new DecoderContext(registry, null, null));
+            new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -200,7 +200,7 @@ class RecordDecoderTest {
         RecordDecoder decoder = new RecordDecoder();
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new LeafNode("12345"),
-            TypeCapture.of(Person.class), new DecoderContext(registry, null, null));
+            TypeCapture.of(Person.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertFalse(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -219,7 +219,7 @@ class RecordDecoderTest {
         configs.put("identity", new LeafNode("52"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(),
-                new MapNode(configs), TypeCapture.of(PersonAnnotations.class), new DecoderContext(registry, null, null));
+                new MapNode(configs), TypeCapture.of(PersonAnnotations.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -236,7 +236,7 @@ class RecordDecoderTest {
         configs.put("name", new LeafNode("tim"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(),
-                new MapNode(configs), TypeCapture.of(PersonAnnotations.class), new DecoderContext(registry, null, null));
+                new MapNode(configs), TypeCapture.of(PersonAnnotations.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 
@@ -259,7 +259,7 @@ class RecordDecoderTest {
 
         GResultOf<Object> result =
             decoder.decode("user.admin", Tags.of(), new MapNode(configs), TypeCapture.of(PersonBadAnnotations.class),
-                new DecoderContext(registry, null, null));
+                new DecoderContext(registry, null, null, new PathLexer()));
 
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
@@ -287,7 +287,7 @@ class RecordDecoderTest {
         configs.put("identity", new MapNode(Map.of("user", new LeafNode("52"))));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(),
-                new MapNode(configs), TypeCapture.of(PersonAnnotationsLong.class), new DecoderContext(registry, null, null));
+                new MapNode(configs), TypeCapture.of(PersonAnnotationsLong.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -305,7 +305,7 @@ class RecordDecoderTest {
         configs.put("id", new LeafNode("52"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs),
-            TypeCapture.of(PersonOptional.class), new DecoderContext(registry, null, null));
+            TypeCapture.of(PersonOptional.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -322,7 +322,7 @@ class RecordDecoderTest {
         configs.put("name", new LeafNode("tim"));
 
         GResultOf<Object> result = decoder.decode("user.admin", Tags.of(), new MapNode(configs),
-            TypeCapture.of(PersonOptional.class), new DecoderContext(registry, null, null));
+            TypeCapture.of(PersonOptional.class), new DecoderContext(registry, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertTrue(result.hasErrors());
 

--- a/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedCollectionDecoderTest.java
+++ b/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedCollectionDecoderTest.java
@@ -53,7 +53,7 @@ class SequencedCollectionDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<SequencedCollection<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -82,7 +82,7 @@ class SequencedCollectionDecoderTest {
         ListDecoder decoder = new ListDecoder();
 
         GResultOf<List<?>> values = decoder.decode("db.hosts", Tags.of(), nodes, new TypeCapture<SequencedCollection<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());

--- a/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedMapDecoderTest.java
+++ b/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedMapDecoderTest.java
@@ -56,7 +56,7 @@ class SequencedMapDecoderTest {
         MapDecoder decoder = new MapDecoder();
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-            new TypeCapture<SequencedMap<String, Integer>>() { }, new DecoderContext(decoderService, null, null));
+            new TypeCapture<SequencedMap<String, Integer>>() { }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -85,7 +85,7 @@ class SequencedMapDecoderTest {
         MapDecoder decoder = new MapDecoder();
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new MapNode(configs),
-                new TypeCapture<SequencedMap<Integer, Integer>>() { }, new DecoderContext(decoderService, null, null));
+                new TypeCapture<SequencedMap<Integer, Integer>>() { }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 
@@ -108,7 +108,7 @@ class SequencedMapDecoderTest {
 
         GResultOf<Map<?, ?>> result = decoder.decode("db.host", Tags.of(), new LeafNode("port=100,uri=300,password=6000"),
             new TypeCapture<SequencedMap<String, Integer>>() {
-            }, new DecoderContext(decoderService, null, null));
+            }, new DecoderContext(decoderService, null, null, new PathLexer()));
         Assertions.assertTrue(result.hasResults());
         Assertions.assertFalse(result.hasErrors());
 

--- a/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedSetDecoderTest.java
+++ b/gestalt-test/src/test/java/org/github/gestalt/config/decoder/SequencedSetDecoderTest.java
@@ -63,7 +63,7 @@ class SequencedSetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<SequencedSet<String>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());
@@ -97,7 +97,7 @@ class SequencedSetDecoderTest {
         SetDecoder decoder = new SetDecoder();
 
         GResultOf<Set<?>> values = decoder.decode("", Tags.of(), nodes, new TypeCapture<SequencedSet<Double>>() {
-        }, new DecoderContext(decoderService, null, null));
+        }, new DecoderContext(decoderService, null, null, new PathLexer()));
 
         Assertions.assertFalse(values.hasErrors());
         Assertions.assertTrue(values.hasResults());

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
@@ -177,7 +177,7 @@ public final class TomlLoader implements ConfigLoader {
             String key = normalizeSentence(entry.getKey());
             JsonNode jsonValue = entry.getValue();
 
-            String currentPath = PathUtil.pathForKey(path, key);
+            String currentPath = PathUtil.pathForKey(lexer, path, key);
 
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, jsonValue);
             errors.addAll(node.getErrors());

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
@@ -153,7 +153,7 @@ public final class TomlLoader implements ConfigLoader {
         List<ConfigNode> array = new ArrayList<>();
         int arraySize = jsonNode.size();
         for (int i = 0; i < arraySize; i++) {
-            String currentPath = PathUtil.pathForIndex(path, i);
+            String currentPath = PathUtil.pathForIndex(lexer, path, i);
 
             JsonNode arrayNodes = jsonNode.get(i);
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, arrayNodes);

--- a/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
+++ b/gestalt-toml/src/main/java/org/github/gestalt/config/toml/TomlLoader.java
@@ -148,6 +148,10 @@ public final class TomlLoader implements ConfigLoader {
         return lexer.normalizeSentence(sentence);
     }
 
+    private List<String> tokenizer(String sentence) {
+        return lexer.tokenizer(sentence);
+    }
+
     private GResultOf<ConfigNode> buildArrayConfigTree(String path, JsonNode jsonNode) {
         List<ValidationError> errors = new ArrayList<>();
         List<ConfigNode> array = new ArrayList<>();
@@ -175,16 +179,23 @@ public final class TomlLoader implements ConfigLoader {
         for (Iterator<Map.Entry<String, JsonNode>> it = jsonNode.fields(); it.hasNext(); ) {
             Map.Entry<String, JsonNode> entry = it.next();
             String key = normalizeSentence(entry.getKey());
+            List<String> tokenList = tokenizer(key);
+            String currentPath = PathUtil.pathForKey(lexer, path, tokenList);
+
             JsonNode jsonValue = entry.getValue();
-
-            String currentPath = PathUtil.pathForKey(lexer, path, key);
-
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, jsonValue);
             errors.addAll(node.getErrors());
             if (!node.hasResults()) {
                 errors.add(new ValidationError.NoResultsFoundForPath(currentPath));
             } else {
-                mapNode.put(key, node.results());
+                ConfigNode currentNode = node.results();
+                for (int i = tokenList.size() - 1; i > 0; i--) {
+                    Map<String, ConfigNode> nextMapNode = new HashMap<>();
+                    nextMapNode.put(tokenList.get(i), currentNode);
+                    currentNode = new MapNode(nextMapNode);
+                }
+
+                mapNode.put(tokenList.get(0), currentNode);
             }
         }
 

--- a/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
+++ b/gestalt-toml/src/test/java/org/github/gestalt/config/toml/TomlLoaderTest.java
@@ -80,6 +80,51 @@ class TomlLoaderTest {
     }
 
     @Test
+    void loadSourceLexedMultiPath() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("user.name = \"Steve\" \n" +
+            "age = 42\n" +
+
+            "[[cars]]\n" +
+            "name = \"Ford\"\n" +
+            "models = [ \"Fiesta\", \"Focus\", \"Mustang\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"BMW\"\n" +
+            "models = [ \"320\", \"X3\", \"X5\" ]\n" +
+
+            "[[cars]]\n" +
+            "name = \"Fiat\"\n" +
+            "models = [ \"500\", \"Panda\" ]\n", "toml");
+
+        TomlLoader tomlLoader = new TomlLoader();
+
+        GestaltConfig config = new GestaltConfig();
+        config.setSentenceLexer(new PathLexer());
+
+        tomlLoader.applyConfig(config);
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = tomlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("user").get().getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceWithModuleConfig() throws GestaltException {
         var lexer = new PathLexer();
         var objectMapper = new ObjectMapper(new TomlFactory()).findAndRegisterModules();

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
@@ -182,7 +182,7 @@ public final class YamlLoader implements ConfigLoader {
             String key = normalizeSentence(entry.getKey());
             JsonNode jsonValue = entry.getValue();
 
-            String currentPath = PathUtil.pathForKey(path, key);
+            String currentPath = PathUtil.pathForKey(lexer, path, key);
 
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, jsonValue);
             errors.addAll(node.getErrors());

--- a/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
+++ b/gestalt-yaml/src/main/java/org/github/gestalt/config/yaml/YamlLoader.java
@@ -158,7 +158,7 @@ public final class YamlLoader implements ConfigLoader {
         List<ConfigNode> array = new ArrayList<>();
         int arraySize = jsonNode.size();
         for (int i = 0; i < arraySize; i++) {
-            String currentPath = PathUtil.pathForIndex(path, i);
+            String currentPath = PathUtil.pathForIndex(lexer, path, i);
 
             JsonNode arrayNodes = jsonNode.get(i);
             GResultOf<ConfigNode> node = buildConfigTree(currentPath, arrayNodes);

--- a/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
+++ b/gestalt-yaml/src/test/java/org/github/gestalt/config/yaml/YamlLoaderTest.java
@@ -287,6 +287,41 @@ class YamlLoaderTest {
     }
 
     @Test
+    void loadSourceLexedPath() throws GestaltException {
+
+        StringConfigSource source = new StringConfigSource("user.name: Steve\n" +
+            "age: 42\n" +
+            "cars: \n" +
+            "  - name: Ford\n" +
+            "    models: [Fiesta, Focus, Mustang]\n" +
+            "  - name: BMW\n" +
+            "    models: [320, X3, X5]\n" +
+            "  - name: Fiat\n" +
+            "    models: [500, Panda]", "yml");
+
+        YamlLoader yamlLoader = new YamlLoader(new ObjectMapper(new YAMLFactory()), new PathLexer());
+
+        GResultOf<List<ConfigNodeContainer>> resultContainer = yamlLoader.loadSource(new ConfigSourcePackage(source, List.of(), Tags.of()));
+
+        Assertions.assertFalse(resultContainer.hasErrors());
+        Assertions.assertTrue(resultContainer.hasResults());
+
+        ConfigNode result = resultContainer.results().get(0).getConfigNode();
+        Assertions.assertEquals("Steve", result.getKey("user").get().getKey("name").get().getValue().get());
+        Assertions.assertEquals("42", result.getKey("age").get().getValue().get());
+        Assertions.assertEquals("Ford", result.getKey("cars").get().getIndex(0).get().getKey("name")
+            .get().getValue().get());
+        Assertions.assertEquals("Fiesta", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(0).get().getValue().get());
+        Assertions.assertEquals("Focus", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(1).get().getValue().get());
+        Assertions.assertEquals("Mustang", result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(2).get().getValue().get());
+        Assertions.assertFalse(result.getKey("cars").get().getIndex(0).get().getKey("models")
+            .get().getIndex(3).isPresent());
+    }
+
+    @Test
     void loadSourceEmptyValue() throws GestaltException {
 
         StringConfigSource source = new StringConfigSource("name: Steve\n" +

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,20 +7,17 @@ kotlin = "1.9.23"
 kotlinDokka = "1.9.20"
 # Kotlin DI
 kodeinDI = "7.21.2"
-koinDI = "3.5.4"
+koinDI = "3.5.5"
 # Java DI
 guice = "7.0.0"
-# @pin
-cdi = "3.0.0"
-# @pin
-weld = "3.1.0.Final"
-# @pin
-weldCore = "4.0.3.Final"
+cdi = "4.0.1"
+weld = "4.0.3.Final"
+weldCore = "5.1.2.Final"
 #encoding/decoding
 jackson = "2.17.0"
 hocon = "1.4.3"
 # Cloud
-awsBom = "2.25.26"
+awsBom = "2.25.30"
 gcpLibraries = "26.37.0"
 # vault
 vault = "6.2.0"
@@ -28,7 +25,7 @@ vault = "6.2.0"
 jgit = "6.9.0.202403050737-r"
 eddsa = "0.3.0"
 # metrics
-micrometer = "1.12.4"
+micrometer = "1.12.5"
 # validation
 hibernateValidator = "8.0.1.Final"
 expressly = "5.0.0"


### PR DESCRIPTION
feat: use the common lexer to rebuild a normalized string instead of hardcoding "."
feat: move array open close and map key value separator to the lexer.
feat: Add a builder for the path lexer.
feat: path lexer supports delimiters matching multiple tokens.
feat: use the path lexer on the yaml, json, toml and hocon to split paths.
fix: remove the escape string from the map decoder.