### PR TITLE
Feat/tag resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,48 @@ The available strategies are:
 | SubsetTagsWithDefaultTagResolutionStrategy  | Subset     | Will Search for any roots that are a subset of the tags provided with a fallback of the default root. In combination with default tags, this can be used to create a profile system similar to Spring Config.    |
 
 
+##### Tags Merging Strategies.
+
+You can provide tags to gestalt in two ways, setting the defaults in the gestalt config and passing in tags when getting a configuration. 
+
+```java
+Gestalt gestalt = new GestaltBuilder()
+.addSource(ClassPathConfigSourceBuilder.builder().setResource("/default.properties").build())  // Load the default property files from resources.
+.addSource(FileConfigSourceBuilder.builder().setFile(devFile).setTags(Tags.profile("dev").build()))
+.addSource(FileConfigSourceBuilder.builder().setFile(testFile).setTags(Tags.profile("test").build()))
+.setDefaultTags(Tags.profile("dev"))
+.build();
+
+// will use the Tags.profile("test") and ignore the default tags of Tags.profile("dev"), so it will use values from the testFile.
+HttpPool pool = gestalt.getConfig("http.pool", HttpPool.class, Tags.profile("test"));
+```
+
+The default behaviour is to use the provided tags with the `getConfig` and if not provided, fall back to the defaults. 
+
+By passing in the TagMergingStrategy to the GestaltBuilder, you can set your own strategy. 
+
+```java
+Gestalt gestalt = new GestaltBuilder()
+      .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
+      .addSource(MapConfigSourceBuilder.builder()
+          .setCustomConfig(configs2)
+          .addTag(Tag.profile("orange"))
+          .addTag(Tag.profile("flower"))
+          .build())
+      .setTagMergingStrategy(new TagMergingStrategyCombine())
+      .build();
+```
+
+The available strategies are:
+
+| name                           | Set Theory   | Description                                                                         |
+|--------------------------------|--------------|-------------------------------------------------------------------------------------|
+| TagMergingStrategyFallback     | exclusive or | Use the provided tags with `getConfig`, and if not provided use a default fallback. |
+| TagMergingStrategyCombine      | union        | Merge the provided tags with `getConfig`, and the defaults                          |
+
+You can provide your own strategy by implementing TagMergingStrategy.
+
+
 #### Example
 Example of how to create and load a configuration objects using Gestalt:
 ```java

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCache.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCache.java
@@ -32,6 +32,7 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
      * @param defaultTags Default set of tags to apply to all calls to get a configuration where tags are not provided.
      * @param observationManager Observations manager for submitting Observations
      * @param gestaltConfig Gestalt Configuration
+     * @param tagMergingStrategy The strategy to merge tags
      */
     public GestaltCache(Gestalt delegate, Tags defaultTags, ObservationManager observationManager, GestaltConfig gestaltConfig,
                         TagMergingStrategy tagMergingStrategy) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCache.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCache.java
@@ -2,16 +2,14 @@ package org.github.gestalt.config;
 
 import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.node.TagMergingStrategy;
 import org.github.gestalt.config.observations.ObservationManager;
 import org.github.gestalt.config.reflect.TypeCapture;
 import org.github.gestalt.config.reload.CoreReloadListener;
 import org.github.gestalt.config.tag.Tags;
 import org.github.gestalt.config.utils.Triple;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * A cache layer that stores configurations by path and type.
@@ -25,6 +23,7 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
     private final Tags defaultTags;
     private final ObservationManager observationManager;
     private final GestaltConfig gestaltConfig;
+    private final TagMergingStrategy tagMergingStrategy;
 
     /**
      * Constructor for the GestaltCache that accepts a delegate.
@@ -34,11 +33,14 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
      * @param observationManager Observations manager for submitting Observations
      * @param gestaltConfig Gestalt Configuration
      */
-    public GestaltCache(Gestalt delegate, Tags defaultTags, ObservationManager observationManager, GestaltConfig gestaltConfig) {
+    public GestaltCache(Gestalt delegate, Tags defaultTags, ObservationManager observationManager, GestaltConfig gestaltConfig,
+                        TagMergingStrategy tagMergingStrategy) {
+        Objects.requireNonNull(tagMergingStrategy);
         this.delegate = delegate;
         this.defaultTags = defaultTags;
         this.observationManager = observationManager;
         this.gestaltConfig = gestaltConfig;
+        this.tagMergingStrategy = tagMergingStrategy;
     }
 
     @Override
@@ -49,32 +51,51 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
 
     @Override
     public <T> T getConfig(String path, Class<T> klass) throws GestaltException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfig(path, typeCapture);
+        return getConfigInternal(path, typeCapture, null);
     }
 
     @Override
     public <T> T getConfig(String path, Class<T> klass, Tags tags) throws GestaltException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfig(path, typeCapture, tags);
+        return getConfigInternal(path, typeCapture, tags);
     }
 
     @Override
     public <T> T getConfig(String path, TypeCapture<T> klass) throws GestaltException {
-        return getConfig(path, klass, defaultTags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
+        return getConfigInternal(path, klass, null);
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
     public <T> T getConfig(String path, TypeCapture<T> klass, Tags tags) throws GestaltException {
-        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, tags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
+        return getConfigInternal(path, klass, tags);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getConfigInternal(String path, TypeCapture<T> klass, Tags tags) throws GestaltException {
+
+        Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, resolvedTags);
         if (cache.get(key) != null) {
             if (gestaltConfig.isObservationsEnabled() && observationManager != null) {
                 observationManager.recordObservation("cache.hit", 1, Tags.of());
             }
             return (T) cache.get(key);
         } else {
-            T result = delegate.getConfig(path, klass, tags);
+            T result = delegate.getConfig(path, klass, resolvedTags);
             cache.put(key, result);
             return result;
         }
@@ -82,27 +103,46 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
 
     @Override
     public <T> T getConfig(String path, T defaultVal, Class<T> klass) {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfig(path, defaultVal, typeCapture);
+        return getConfigInternal(path, defaultVal, typeCapture, null);
     }
 
     @Override
     public <T> T getConfig(String path, T defaultVal, Class<T> klass, Tags tags) {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfig(path, defaultVal, typeCapture, tags);
+        return getConfigInternal(path, defaultVal, typeCapture, tags);
     }
 
 
     @Override
 
     public <T> T getConfig(String path, T defaultVal, TypeCapture<T> klass) {
-        return getConfig(path, defaultVal, klass, defaultTags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
+        return getConfigInternal(path, defaultVal, klass, null);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> T getConfig(String path, T defaultVal, TypeCapture<T> klass, Tags tags) {
-        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, tags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
+        return getConfigInternal(path, defaultVal, klass, tags);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getConfigInternal(String path, T defaultVal, TypeCapture<T> klass, Tags tags) {
+        Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, resolvedTags);
         if (cache.containsKey(key)) {
             T result = (T) cache.get(key);
             if (result == null) {
@@ -116,7 +156,7 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
             return result;
 
         } else {
-            Optional<T> resultOptional = delegate.getConfigOptional(path, klass, tags);
+            Optional<T> resultOptional = delegate.getConfigOptional(path, klass, resolvedTags);
             T result = resultOptional.orElse(null);
             cache.put(key, result);
             if (result != null) {
@@ -129,25 +169,45 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, Class<T> klass) {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfigOptional(path, typeCapture);
+        return getConfigOptionalInternal(path, typeCapture, null);
     }
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, Class<T> klass, Tags tags) {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
         TypeCapture<T> typeCapture = TypeCapture.of(klass);
-        return getConfigOptional(path, typeCapture, tags);
+        return getConfigOptionalInternal(path, typeCapture, tags);
     }
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, TypeCapture<T> klass) {
-        return getConfigOptional(path, klass, defaultTags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
+        return getConfigOptionalInternal(path, klass, null);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public <T> Optional<T> getConfigOptional(String path, TypeCapture<T> klass, Tags tags) {
-        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, tags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
+
+        return  getConfigOptionalInternal(path, klass, tags);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> getConfigOptionalInternal(String path, TypeCapture<T> klass, Tags tags) {
+
+        Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+        Triple<String, TypeCapture<?>, Tags> key = new Triple<>(path, klass, resolvedTags);
         if (cache.containsKey(key)) {
             if (gestaltConfig.isObservationsEnabled() && observationManager != null) {
                 observationManager.recordObservation("cache.hit", 1, Tags.of());
@@ -156,7 +216,7 @@ public class GestaltCache implements Gestalt, CoreReloadListener {
             T result = (T) cache.get(key);
             return Optional.ofNullable(result);
         } else {
-            Optional<T> resultOptional = delegate.getConfigOptional(path, klass, tags);
+            Optional<T> resultOptional = delegate.getConfigOptional(path, klass, resolvedTags);
             T result = resultOptional.orElse(null);
             cache.put(key, result);
             return Optional.ofNullable(result);

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
@@ -87,6 +87,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
      * @param observationManager       Manages reporting of observations
      * @param resultsProcessorManager    Validation Manager, for validating configuration objects
      * @param defaultTags          Default set of tags to apply to all calls to get a configuration where tags are not provided.
+     * @param tagMergingStrategy   Strategy for how to merge tags
      */
     public GestaltCore(ConfigLoaderService configLoaderService, List<ConfigSourcePackage> configSourcePackages,
                        DecoderService decoderService, SentenceLexer sentenceLexer, GestaltConfig gestaltConfig,

--- a/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/GestaltCore.java
@@ -12,6 +12,7 @@ import org.github.gestalt.config.exceptions.GestaltException;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.loader.ConfigLoader;
 import org.github.gestalt.config.loader.ConfigLoaderService;
+import org.github.gestalt.config.node.TagMergingStrategy;
 import org.github.gestalt.config.observations.ObservationManager;
 import org.github.gestalt.config.observations.ObservationMarker;
 import org.github.gestalt.config.node.ConfigNode;
@@ -68,6 +69,8 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
 
     private final DecoderContext decoderContext;
 
+    private final TagMergingStrategy tagMergingStrategy;
+
     /**
      * Constructor for Gestalt,you can call it manually but the best way to use this is though the GestaltBuilder.
      *
@@ -89,7 +92,8 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
                        DecoderService decoderService, SentenceLexer sentenceLexer, GestaltConfig gestaltConfig,
                        ConfigNodeService configNodeService, CoreReloadListenersContainer reloadStrategy,
                        List<ConfigNodeProcessor> configNodeProcessor, SecretConcealer secretConcealer,
-                       ObservationManager observationManager, ResultsProcessorManager resultsProcessorManager, Tags defaultTags) {
+                       ObservationManager observationManager, ResultsProcessorManager resultsProcessorManager,
+                       Tags defaultTags, TagMergingStrategy tagMergingStrategy) {
         this.configLoaderService = configLoaderService;
         this.sourcePackages = configSourcePackages;
         this.decoderService = decoderService;
@@ -103,6 +107,7 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         this.resultsProcessorManager = resultsProcessorManager;
         this.defaultTags = defaultTags;
         this.decoderContext = new DecoderContext(decoderService, this, secretConcealer, sentenceLexer);
+        this.tagMergingStrategy = tagMergingStrategy;
     }
 
     List<ValidationError> getLoadErrors() {
@@ -275,21 +280,27 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
 
     @Override
     public <T> T getConfig(String path, Class<T> klass) throws GestaltException {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
 
-        return getConfig(path, TypeCapture.of(klass));
+        return getConfig2(path, TypeCapture.of(klass), null);
     }
 
     @Override
     public <T> T getConfig(String path, Class<T> klass, Tags tags) throws GestaltException {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
 
-        return getConfig(path, TypeCapture.of(klass), tags);
+        return getConfig2(path, TypeCapture.of(klass), tags);
     }
 
     @Override
     public <T> T getConfig(String path, TypeCapture<T> klass) throws GestaltException {
-        return getConfig(path, klass, defaultTags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
+        return getConfig2(path, klass, null);
     }
 
     @Override
@@ -298,43 +309,59 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         Objects.requireNonNull(klass);
         Objects.requireNonNull(tags);
 
+        return getConfig2(path, klass, tags);
+    }
+
+    private <T> T getConfig2(String path, TypeCapture<T> klass, Tags tags) throws GestaltException {
+
         // fail on errors if this is not an optional type.
         // get the default value used if this is an optional type
         // most likely an optional.empty()
         Pair<Boolean, T> isOptionalAndDefault = ClassUtils.isOptionalAndDefault(klass.getRawType());
 
-        return getConfigurationInternal(path, !isOptionalAndDefault.getFirst(), isOptionalAndDefault.getSecond(), klass, tags);
+        Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+        return getConfigurationInternal(path, !isOptionalAndDefault.getFirst(), isOptionalAndDefault.getSecond(), klass, resolvedTags);
     }
 
     @Override
     public <T> T getConfig(String path, T defaultVal, Class<T> klass) {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
 
-        return getConfig(path, defaultVal, TypeCapture.of(klass));
+        return getConfig2(path, defaultVal, TypeCapture.of(klass), null);
     }
 
     @Override
     public <T> T getConfig(String path, T defaultVal, Class<T> klass, Tags tags) {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
 
-        return getConfig(path, defaultVal, TypeCapture.of(klass), tags);
+        return getConfig2(path, defaultVal, TypeCapture.of(klass), null);
 
     }
 
     @Override
     public <T> T getConfig(String path, T defaultVal, TypeCapture<T> klass) {
-        return getConfig(path, defaultVal, klass, defaultTags);
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(klass);
+
+        return getConfig2(path, defaultVal, klass, null);
     }
 
     @Override
     public <T> T getConfig(String path, T defaultVal, TypeCapture<T> klass, Tags tags) {
         Objects.requireNonNull(path);
-        Objects.requireNonNull(defaultVal);
         Objects.requireNonNull(klass);
         Objects.requireNonNull(tags);
 
+        return getConfig2(path, defaultVal, klass, tags);
+    }
+
+    private <T> T getConfig2(String path, T defaultVal, TypeCapture<T> klass, Tags tags) {
         try {
-            return getConfigurationInternal(path, false, defaultVal, klass, tags);
+            Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+            return getConfigurationInternal(path, false, defaultVal, klass, resolvedTags);
         } catch (GestaltException e) {
             logger.log(WARNING, e.getMessage());
         }
@@ -344,23 +371,27 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, Class<T> klass) {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
 
-        return getConfigOptional(path, TypeCapture.of(klass));
+        return getConfigOptional2(path, TypeCapture.of(klass), defaultTags);
     }
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, Class<T> klass, Tags tags) {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
+        Objects.requireNonNull(tags);
 
-        return getConfigOptional(path, TypeCapture.of(klass), tags);
+        return getConfigOptional2(path, TypeCapture.of(klass), tags);
     }
 
     @Override
     public <T> Optional<T> getConfigOptional(String path, TypeCapture<T> klass) {
+        Objects.requireNonNull(path);
         Objects.requireNonNull(klass);
 
-        return getConfigOptional(path, klass, defaultTags);
+        return getConfigOptional2(path, klass, defaultTags);
     }
 
     @Override
@@ -369,8 +400,13 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
         Objects.requireNonNull(klass);
         Objects.requireNonNull(tags);
 
+        return getConfigOptional2(path, klass, tags);
+    }
+
+    private <T> Optional<T> getConfigOptional2(String path, TypeCapture<T> klass, Tags tags) {
         try {
-            var results = getConfigurationInternal(path, false, null, klass, tags);
+            Tags resolvedTags = tagMergingStrategy.mergeTags(tags, defaultTags);
+            var results = getConfigurationInternal(path, false, null, klass, resolvedTags);
             return Optional.ofNullable(results);
         } catch (GestaltException e) {
             logger.log(WARNING, e.getMessage());
@@ -382,9 +418,6 @@ public class GestaltCore implements Gestalt, ConfigReloadListener {
     private <T> T getConfigurationInternal(String path, boolean failOnErrors, T defaultVal, TypeCapture<T> klass, Tags tags)
         throws GestaltException {
 
-        Objects.requireNonNull(path);
-        Objects.requireNonNull(klass);
-        Objects.requireNonNull(tags);
         ObservationMarker getConfigMarker = null;
         boolean defaultReturned = false;
         Exception exceptionThrown = null;

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategy.java
@@ -12,7 +12,7 @@ public interface TagMergingStrategy {
     /**
      * Merges the tags provided with the request and the default tags, then returns the results.
      *
-     * @param provided the tags provided with the request
+     * @param provided the tags provided with the request, can be null if not provided
      * @param defaultTags the default tags registered with Gestalt
      * @return the merged results
      */

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategy.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategy.java
@@ -1,0 +1,20 @@
+package org.github.gestalt.config.node;
+
+import org.github.gestalt.config.tag.Tags;
+
+/**
+ * Merges the tags provided with the request and the default tags, then returns the results.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
+public interface TagMergingStrategy {
+
+    /**
+     * Merges the tags provided with the request and the default tags, then returns the results.
+     *
+     * @param provided the tags provided with the request
+     * @param defaultTags the default tags registered with Gestalt
+     * @return the merged results
+     */
+    Tags mergeTags(Tags provided, Tags defaultTags);
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyCombine.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyCombine.java
@@ -1,0 +1,14 @@
+package org.github.gestalt.config.node;
+
+import org.github.gestalt.config.tag.Tags;
+
+public class TagMergingStrategyCombine implements TagMergingStrategy {
+    @Override
+    public Tags mergeTags(Tags provided, Tags defaultTags) {
+        if (provided != null && provided != Tags.of()) {
+            return provided.and(defaultTags);
+        } else {
+            return defaultTags;
+        }
+    }
+}

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyCombine.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyCombine.java
@@ -2,6 +2,11 @@ package org.github.gestalt.config.node;
 
 import org.github.gestalt.config.tag.Tags;
 
+/**
+ * Merges the tags provided with the request and the default tags, then returns the results.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
 public class TagMergingStrategyCombine implements TagMergingStrategy {
     @Override
     public Tags mergeTags(Tags provided, Tags defaultTags) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyFallback.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyFallback.java
@@ -2,6 +2,11 @@ package org.github.gestalt.config.node;
 
 import org.github.gestalt.config.tag.Tags;
 
+/**
+ * Accepts the tags provided or fallback to the defaults.
+ *
+ * @author <a href="mailto:colin.redmond@outlook.com"> Colin Redmond </a> (c) 2024.
+ */
 public class TagMergingStrategyFallback implements TagMergingStrategy {
     @Override
     public Tags mergeTags(Tags provided, Tags defaultTags) {

--- a/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyFallback.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/node/TagMergingStrategyFallback.java
@@ -1,0 +1,14 @@
+package org.github.gestalt.config.node;
+
+import org.github.gestalt.config.tag.Tags;
+
+public class TagMergingStrategyFallback implements TagMergingStrategy {
+    @Override
+    public Tags mergeTags(Tags provided, Tags defaultTags) {
+        if (provided != null) {
+            return provided;
+        } else {
+            return defaultTags;
+        }
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/GestaltCacheTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/GestaltCacheTest.java
@@ -2,6 +2,7 @@ package org.github.gestalt.config;
 
 import org.github.gestalt.config.entity.GestaltConfig;
 import org.github.gestalt.config.exceptions.GestaltException;
+import org.github.gestalt.config.node.TagMergingStrategyFallback;
 import org.github.gestalt.config.reflect.TypeCapture;
 import org.github.gestalt.config.reload.CoreReloadListener;
 import org.github.gestalt.config.tag.Tags;
@@ -36,7 +37,8 @@ class GestaltCacheTest {
 
     @Test
     void loadConfigs() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig(),
+            new TagMergingStrategyFallback());
 
         cache.loadConfigs();
 
@@ -45,7 +47,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfig() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(100);
 
         Integer port = cache.getConfig("db.port", Integer.class);
@@ -63,7 +66,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfig2() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(100);
 
         Integer port = cache.getConfig("db.port", TypeCapture.of(Integer.class));
@@ -81,7 +85,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigTags() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Tags tags = Tags.of("toys", "ball");
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), tags)).thenReturn(100);
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(500);
@@ -109,7 +114,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigDefault() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(Optional.of(100));
 
         Integer port = cache.getConfig("db.port", 200, Integer.class);
@@ -127,7 +133,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfig2Default() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(Optional.of(100));
 
         Integer port = cache.getConfig("db.port", 200, TypeCapture.of(Integer.class));
@@ -146,7 +153,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigDefaultTags() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Tags tags = Tags.of("toys", "ball");
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), tags)).thenReturn(Optional.of(100));
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(Optional.of(500));
@@ -174,7 +182,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigDefaultMissing() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of()))
             .thenReturn(Optional.empty());
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of()))
@@ -197,7 +206,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigOptional() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(Optional.of(100));
 
         Optional<Integer> port = cache.getConfigOptional("db.port", Integer.class);
@@ -215,7 +225,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfig2Optional() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of()))
             .thenReturn(Optional.of(100));
 
@@ -234,7 +245,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigOptionalEmpty() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of()))
             .thenReturn(Optional.empty());
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of()))
@@ -258,7 +270,8 @@ class GestaltCacheTest {
 
     @Test
     void getConfigOptionalTags() throws GestaltException {
-        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, Tags.of(), null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Tags tags = Tags.of("toys", "ball");
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), tags)).thenReturn(Optional.of(100));
         Mockito.when(mockGestalt.getConfigOptional("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(Optional.of(500));
@@ -285,7 +298,8 @@ class GestaltCacheTest {
     @Test
     void getConfigDefaultTags2() throws GestaltException {
         Tags defaultTags = Tags.of("env", "dev");
-        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), defaultTags)).thenReturn(100);
         Mockito.when(mockGestalt.getConfig("db.port", TypeCapture.of(Integer.class), Tags.of())).thenReturn(200);
 
@@ -308,7 +322,8 @@ class GestaltCacheTest {
     @Test
     void getListeners() throws GestaltException {
         Tags defaultTags = Tags.of("env", "dev");
-        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
 
         CoreReloadListener listener = () -> {
 
@@ -323,7 +338,8 @@ class GestaltCacheTest {
     @Test
     void debugPrint() throws GestaltException {
         Tags defaultTags = Tags.of("env", "dev");
-        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null, new GestaltConfig());
+        GestaltCache cache = new GestaltCache(mockGestalt, defaultTags, null,
+            new GestaltConfig(), new TagMergingStrategyFallback());
 
         Mockito.when(mockGestalt.debugPrint()).thenReturn("test");
         Mockito.when(mockGestalt.debugPrint(Tags.environment("dev"))).thenReturn("dev");

--- a/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
@@ -13,10 +13,7 @@ import org.github.gestalt.config.loader.ConfigLoader;
 import org.github.gestalt.config.loader.ConfigLoaderRegistry;
 import org.github.gestalt.config.loader.EnvironmentVarsLoaderModuleConfigBuilder;
 import org.github.gestalt.config.loader.MapConfigLoader;
-import org.github.gestalt.config.node.ConfigNode;
-import org.github.gestalt.config.node.ConfigNodeManager;
-import org.github.gestalt.config.node.LeafNode;
-import org.github.gestalt.config.node.MapNode;
+import org.github.gestalt.config.node.*;
 import org.github.gestalt.config.path.mapper.StandardPathMapper;
 import org.github.gestalt.config.processor.config.ConfigNodeProcessor;
 import org.github.gestalt.config.processor.result.DefaultResultProcessor;
@@ -525,7 +522,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), configNodeManager, null,
-            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null, Tags.of());
+            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null,
+            Tags.of(), new TagMergingStrategyFallback());
 
         Mockito.when(configNodeManager.postProcess(Mockito.any())).thenReturn(GResultOf.resultOf(null, Collections.emptyList()));
 
@@ -556,7 +554,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), configNodeManager, null,
-            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null, Tags.of());
+            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null,
+            Tags.of(), new TagMergingStrategyFallback());
 
         Mockito.when(configNodeManager.postProcess(Mockito.any())).thenReturn(
             GResultOf.resultOf(true, Collections.singletonList(new ValidationError.ArrayInvalidIndex(-1, "test"))));
@@ -591,7 +590,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, config, configNodeManager, null,
-            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null, Tags.of());
+            Collections.singletonList(new TestConfigNodeProcessor("aaa")), secretConcealer, null, null,
+            Tags.of(), new TagMergingStrategyFallback());
 
         Mockito.when(configNodeManager.postProcess(Mockito.any())).thenReturn(
             GResultOf.resultOf(true, Collections.singletonList(new ValidationError.ArrayMissingIndex(1, "test"))));
@@ -849,7 +849,7 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), new ConfigNodeManager(), null, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of());
+            null, null, Tags.of(), new TagMergingStrategyFallback());
 
         var ex = Assertions.assertThrows(GestaltException.class, () -> gestalt.loadConfigs());
         assertThat(ex).isInstanceOf(GestaltException.class)
@@ -870,7 +870,7 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), new ConfigNodeManager(), null, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of());
+            null, null, Tags.of(), new TagMergingStrategyFallback());
 
         var ex = Assertions.assertThrows(GestaltException.class, () -> gestalt.loadConfigs());
         assertThat(ex).isInstanceOf(GestaltException.class)
@@ -898,7 +898,8 @@ class GestaltTest {
             new DecoderRegistry(Collections.singletonList(new StringDecoder()), configNodeManager, lexer,
                 List.of(new StandardPathMapper())), lexer, new GestaltConfig(), new ConfigNodeManager(), null,
             Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
 
@@ -933,7 +934,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new StringDecoder(), new ExceptionDecoder()), configNodeManager, lexer,
                 List.of(new StandardPathMapper())), lexer, new GestaltConfig(), new ConfigNodeManager(), null,
             Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
 
@@ -968,7 +970,7 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), configNodeManager, null, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of());
+            null, null, Tags.of(), new TagMergingStrategyFallback());
 
         var ex = Assertions.assertThrows(GestaltException.class, gestalt::loadConfigs);
         assertThat(ex).isInstanceOf(GestaltException.class)
@@ -1035,7 +1037,7 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, config, new ConfigNodeManager(), null, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of());
+            null, null, Tags.of(), new TagMergingStrategyFallback());
 
         GestaltConfigurationException e = Assertions.assertThrows(GestaltConfigurationException.class, gestalt::loadConfigs);
         Assertions.assertEquals("No results found for node", e.getMessage());
@@ -1249,7 +1251,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())), lexer, new GestaltConfig(), configNodeManager,
             coreReloadListenersContainer, Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
         List<ValidationError> errors = gestalt.getLoadErrors();
@@ -1312,7 +1315,7 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), configNodeManager, coreReloadListenersContainer, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of());
+            null, null, Tags.of(), new TagMergingStrategyFallback());
 
         var ex = Assertions.assertThrows(GestaltException.class, () -> gestalt.reload(sourcePackage));
         assertThat(ex).hasMessage("No sources provided, unable to reload any configs");
@@ -1347,7 +1350,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())), lexer, new GestaltConfig(),
             configNodeManager, coreReloadListenersContainer, Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
         List<ValidationError> errors = gestalt.getLoadErrors();
@@ -1420,7 +1424,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())), lexer, new GestaltConfig(), configNodeManager,
             coreReloadListenersContainer, Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
         List<ValidationError> errors = gestalt.getLoadErrors();
@@ -1485,7 +1490,8 @@ class GestaltTest {
             new DecoderRegistry(List.of(new DoubleDecoder(), new LongDecoder(), new IntegerDecoder(), new StringDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())), lexer, new GestaltConfig(),
             configNodeManager, coreReloadListenersContainer, Collections.emptyList(), secretConcealer, null,
-            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())), Tags.of());
+            new ResultsProcessorManager(List.of(new ErrorResultProcessor(), new DefaultResultProcessor())),
+            Tags.of(), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
         List<ValidationError> errors = gestalt.getLoadErrors();
@@ -1613,7 +1619,7 @@ class GestaltTest {
                     new OptionalDoubleDecoder(), new OptionalIntDecoder(), new OptionalLongDecoder()),
                 configNodeManager, lexer, List.of(new StandardPathMapper())),
             lexer, new GestaltConfig(), configNodeManager, coreReloadListenersContainer, Collections.emptyList(), secretConcealer,
-            null, null, Tags.of("env", "dev"));
+            null, null, Tags.of("env", "dev"), new TagMergingStrategyFallback());
 
         gestalt.loadConfigs();
 
@@ -2054,6 +2060,48 @@ class GestaltTest {
         Assertions.assertEquals("test", gestalt.getConfig("db", DBInfo.class).getUri());
         Assertions.assertEquals(3306, gestalt.getConfig("db", DBInfo.class).getPort());
         Assertions.assertEquals("abc123", gestalt.getConfig("db", DBInfo.class).getPassword());
+    }
+
+    @Test
+    public void testMergeTags() throws GestaltException {
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put("db.password", "test");
+        configs.put("db.port", "3306");
+        configs.put("db.uri", "my.sql.com");
+
+        Map<String, String> configs2 = new HashMap<>();
+        configs2.put("db.password", "test2");
+        configs2.put("db.port", "456");
+        configs2.put("db.uri", "my.postgresql.com");
+
+        Map<String, String> configs3 = new HashMap<>();
+        configs3.put("db.password", "test3");
+        configs3.put("db.port", "789");
+
+        Gestalt gestalt = new GestaltBuilder()
+            .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
+            .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs2).setTags(Tags.profile("one")).build())
+            .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs3).setTags(Tags.profiles("one", "two")).build())
+            .setTreatWarningsAsErrors(true)
+            .setTagMergingStrategy(new TagMergingStrategyCombine())
+            .setDefaultTags(Tags.profile("one"))
+            .build();
+
+        gestalt.loadConfigs();
+
+        Assertions.assertEquals("test2", gestalt.getConfig("db.password", String.class));
+        Assertions.assertEquals("456", gestalt.getConfig("db.port", String.class));
+        Assertions.assertEquals("my.postgresql.com", gestalt.getConfig("db.uri", String.class));
+
+        Assertions.assertEquals("test2", gestalt.getConfig("db.password", String.class, Tags.profile("one")));
+        Assertions.assertEquals("456", gestalt.getConfig("db.port", String.class, Tags.profile("one")));
+        Assertions.assertEquals("my.postgresql.com", gestalt.getConfig("db.uri", String.class, Tags.profile("one")));
+
+        Assertions.assertEquals("test3", gestalt.getConfig("db.password", String.class, Tags.profile("two")));
+        Assertions.assertEquals("789", gestalt.getConfig("db.port", String.class, Tags.profile("two")));
+        Assertions.assertEquals("my.sql.com", gestalt.getConfig("db.uri", String.class, Tags.profile("two")));
+
     }
 
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/builder/GestaltBuilderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/builder/GestaltBuilderTest.java
@@ -11,6 +11,7 @@ import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.loader.ConfigLoader;
 import org.github.gestalt.config.loader.ConfigLoaderRegistry;
 import org.github.gestalt.config.loader.MapConfigLoader;
+import org.github.gestalt.config.node.TagMergingStrategyFallback;
 import org.github.gestalt.config.observations.ObservationManager;
 import org.github.gestalt.config.observations.TestObservationRecorder;
 import org.github.gestalt.config.node.ConfigNode;
@@ -125,6 +126,7 @@ class GestaltBuilderTest {
             .setResultProcessor(List.of(new TestResultProcessor(true)))
             .setResultsProcessorManager(new ResultsProcessorManager(new ArrayList<>()))
             .setAddCoreResultProcessors(true)
+            .setTagMergingStrategy(new TagMergingStrategyFallback())
             .addValidator(new TestValidationProcessor(true))
             .addValidators(List.of(new TestValidationProcessor(true)))
             .setValidators(List.of(new TestValidationProcessor(true)))

--- a/gestalt-core/src/test/java/org/github/gestalt/config/node/TagMergingStrategyCombineTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/node/TagMergingStrategyCombineTest.java
@@ -1,0 +1,35 @@
+package org.github.gestalt.config.node;
+
+import org.github.gestalt.config.tag.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TagMergingStrategyCombineTest {
+
+    @Test
+    public void testCombine() {
+        var tagMergingStrategy = new TagMergingStrategyCombine();
+
+        var combinedTags = tagMergingStrategy.mergeTags(Tags.profile("test"), Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.profiles("test", "alpha", "beta"), combinedTags);
+    }
+
+    @Test
+    public void testCombineEmpty() {
+        var tagMergingStrategy = new TagMergingStrategyCombine();
+
+        var combinedTags = tagMergingStrategy.mergeTags(Tags.of(), Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.profiles("alpha", "beta"), combinedTags);
+    }
+
+    @Test
+    public void testCombineNull() {
+        var tagMergingStrategy = new TagMergingStrategyCombine();
+
+        var combinedTags = tagMergingStrategy.mergeTags(null, Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.profiles("alpha", "beta"), combinedTags);
+    }
+}

--- a/gestalt-core/src/test/java/org/github/gestalt/config/node/TagMergingStrategyFallbackTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/node/TagMergingStrategyFallbackTest.java
@@ -1,0 +1,35 @@
+package org.github.gestalt.config.node;
+
+import org.github.gestalt.config.tag.Tags;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class TagMergingStrategyFallbackTest {
+
+    @Test
+    public void testCombine() {
+        var tagMergingStrategy = new TagMergingStrategyFallback();
+
+        var combinedTags = tagMergingStrategy.mergeTags(Tags.profile("test"), Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.profiles("test"), combinedTags);
+    }
+
+    @Test
+    public void testCombineEmpty() {
+        var tagMergingStrategy = new TagMergingStrategyFallback();
+
+        var combinedTags = tagMergingStrategy.mergeTags(Tags.of(), Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.of(), combinedTags);
+    }
+
+    @Test
+    public void testCombineNull() {
+        var tagMergingStrategy = new TagMergingStrategyFallback();
+
+        var combinedTags = tagMergingStrategy.mergeTags(null, Tags.profiles("alpha", "beta"));
+
+        Assertions.assertEquals(Tags.profiles("alpha", "beta"), combinedTags);
+    }
+}


### PR DESCRIPTION
Feat: implement a tag merging strategy for merging the tags provided to calls to get a config and the default tags. The current implementation use the provided tags and fall back to the defaults if there are no provided  tags.