### PR TITLE
fix:  MapDecoder doesn't handle nullable ConfigNode inside the canDecode method https://github.com/gestalt-config/gestalt/issues/230

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/MapDecoder.java
@@ -57,7 +57,7 @@ public final class MapDecoder implements Decoder<Map<?, ?>> {
 
     @Override
     public boolean canDecode(String path, Tags tags, ConfigNode node, TypeCapture<?> type) {
-        return Map.class.isAssignableFrom(type.getRawType()) && type.hasParameter() &&
+        return Map.class.isAssignableFrom(type.getRawType()) && type.hasParameter() && node != null &&
             (node.getNodeType() == NodeType.MAP || node.getNodeType() == NodeType.LEAF);
     }
 

--- a/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/GestaltTest.java
@@ -2140,6 +2140,30 @@ class GestaltTest {
         Assertions.assertEquals(111222333, gestalt.getConfig("subservice.booking.token", Integer.class));
     }
 
+    @Test
+    public void testMapWrongNode() throws GestaltException {
+
+        Map<String, String> configs = new HashMap<>();
+        configs.put("db.password", "test");
+        configs.put("db.port", "123");
+        configs.put("db.uri", "my.sql.com");
+
+        Gestalt gestalt = new GestaltBuilder()
+            .addSource(MapConfigSourceBuilder.builder().setCustomConfig(configs).build())
+            .setTreatWarningsAsErrors(false)
+            .build();
+
+        gestalt.loadConfigs();
+
+        var exception = Assertions.assertThrows(GestaltException.class,  () -> gestalt.getConfig("empty", new TypeCapture<Map<String, String>>() {
+        }));
+
+        Assertions.assertEquals("Failed getting config path: empty, for class: " +
+            "java.util.Map<java.lang.String, java.lang.String>\n" +
+            " - level: MISSING_VALUE, message: Unable to find node matching path: empty, " +
+            "for class: ObjectToken, during navigating to next node", exception.getMessage());
+    }
+
 
     public static class TestConfigNodeProcessor implements ConfigNodeProcessor {
         private final String add;

--- a/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/decoder/MapDecoderTest.java
@@ -73,6 +73,9 @@ class MapDecoderTest {
         Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), TypeCapture.of(Date.class)));
         Assertions.assertFalse(decoder.canDecode("", Tags.of(), new LeafNode(""), new TypeCapture<List<Long>>() {
         }));
+
+        Assertions.assertFalse(decoder.canDecode("", Tags.of(), null, new TypeCapture<List<Long>>() {
+        }));
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ checkStyle = "10.10.0"
 jmh = "1.37"
 gradleJmh = "0.7.3"
 # @pin gestalt for integration tests.
-gestalt = "0.35.2"
+gestalt = "0.35.3"
 # Gradle utility
 gradleVersions = "0.52.0"
 gitVersions = "3.1.0"


### PR DESCRIPTION
fix:  MapDecoder doesn't handle nullable ConfigNode inside the canDecode method  https://github.com/gestalt-config/gestalt/issues/230