### PR TITLE
chore: change log level from INFO to TRACE for static field logging

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ObjectDecoder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/decoder/ObjectDecoder.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static java.lang.System.Logger.Level.INFO;
+import static java.lang.System.Logger.Level.TRACE;
 import static java.lang.System.Logger.Level.WARNING;
 
 /**
@@ -117,7 +117,7 @@ public final class ObjectDecoder implements Decoder<Object> {
                 boolean foundValue = false;
 
                 if (Modifier.isStatic(modifiers)) {
-                    logger.log(INFO, "Ignoring static field for class: " + klass.getName() + " field " + fieldName);
+                    logger.log(TRACE, "Ignoring static field for class: " + klass.getName() + " field " + fieldName);
                     continue;
                 }
 


### PR DESCRIPTION
This pull request makes a minor change to the logging level in the `ObjectDecoder` class. The log message for ignoring static fields has been changed from `INFO` to `TRACE`, which will reduce log verbosity during normal operation.

* Changed log level for static field ignore messages from `INFO` to `TRACE` in `ObjectDecoder.java` to reduce unnecessary log output. [[1]](diffhunk://#diff-708611b3de85f2fd708fd25078cbe77b07acc5f6e23f8f9b9e9a9c7917723be6L24-R24) [[2]](diffhunk://#diff-708611b3de85f2fd708fd25078cbe77b07acc5f6e23f8f9b9e9a9c7917723be6L120-R120)