### PR TITLE
feat: Add support for custom file suffixes in PropertyLoader

### DIFF
--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoader.java
@@ -16,10 +16,12 @@ import org.github.gestalt.config.utils.Pair;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -31,6 +33,7 @@ public final class PropertyLoader implements ConfigLoader {
 
     private ConfigParser parser;
     private SentenceLexer lexer;
+    private Set<String> customFileSuffixes;
     private final boolean isDefault;
 
     /**
@@ -57,6 +60,7 @@ public final class PropertyLoader implements ConfigLoader {
         this.lexer = lexer;
         this.parser = parser;
         this.isDefault = isDefault;
+        this.customFileSuffixes = new HashSet<>();
     }
 
     @Override
@@ -77,6 +81,10 @@ public final class PropertyLoader implements ConfigLoader {
         if (isDefault && moduleConfig != null && moduleConfig.getConfigParse() != null) {
             parser = moduleConfig.getConfigParse();
         }
+
+        if (moduleConfig != null && moduleConfig.getCustomFileSuffixes() != null) {
+            customFileSuffixes.addAll(moduleConfig.getCustomFileSuffixes());
+        }
     }
 
     @Override
@@ -86,7 +94,7 @@ public final class PropertyLoader implements ConfigLoader {
 
     @Override
     public boolean accepts(String format) {
-        return "properties".equals(format) || "props".equals(format) || SystemPropertiesConfigSource.SYSTEM_PROPERTIES.equals(format);
+        return "properties".equals(format) || "props".equals(format) || SystemPropertiesConfigSource.SYSTEM_PROPERTIES.equals(format) || customFileSuffixes.contains(format);
     }
 
     /**

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfig.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfig.java
@@ -4,6 +4,9 @@ import org.github.gestalt.config.entity.GestaltModuleConfig;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.parser.ConfigParser;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Gestalt module config for the Property Loader Module.
  *
@@ -13,6 +16,7 @@ public class PropertyLoaderModuleConfig implements GestaltModuleConfig {
 
     private final ConfigParser parser;
     private final SentenceLexer lexer;
+    private final Set<String> customFileSuffixes;
 
     /**
      * Gestalt module config for the Property Loader Module.
@@ -21,8 +25,20 @@ public class PropertyLoaderModuleConfig implements GestaltModuleConfig {
      * @param lexer  the lexer to normalize paths.
      */
     public PropertyLoaderModuleConfig(ConfigParser parser, SentenceLexer lexer) {
+        this(parser, lexer, Collections.emptySet());
+    }
+
+    /**
+     * Gestalt module config for the Property Loader Module.
+     *
+     * @param parser                options for the ConfigParser
+     * @param lexer                 the lexer to normalize paths.
+     * @param customFileSuffixes    custom file suffixes to accept (e.g. "conf")
+     */
+    public PropertyLoaderModuleConfig(ConfigParser parser, SentenceLexer lexer, Set<String> customFileSuffixes) {
         this.parser = parser;
         this.lexer = lexer;
+        this.customFileSuffixes = customFileSuffixes;
     }
 
     @Override
@@ -46,5 +62,15 @@ public class PropertyLoaderModuleConfig implements GestaltModuleConfig {
      */
     public SentenceLexer getLexer() {
         return lexer;
+    }
+    
+
+    /**
+     * Get the custom file suffixes for the Property Loader module.
+     *
+     * @return custom file suffixes
+     */
+    public Set<String> getCustomFileSuffixes() {
+        return customFileSuffixes;
     }
 }

--- a/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilder.java
+++ b/gestalt-core/src/main/java/org/github/gestalt/config/loader/PropertyLoaderModuleConfigBuilder.java
@@ -3,6 +3,9 @@ package org.github.gestalt.config.loader;
 import org.github.gestalt.config.lexer.SentenceLexer;
 import org.github.gestalt.config.parser.ConfigParser;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Gestalt module config for the Property Loader Module builder.
  *
@@ -11,6 +14,7 @@ import org.github.gestalt.config.parser.ConfigParser;
 public final class PropertyLoaderModuleConfigBuilder {
     private ConfigParser parser;
     private SentenceLexer lexer;
+    private Set<String> customFileSuffixes = new HashSet<>();
 
     private PropertyLoaderModuleConfigBuilder() {
     }
@@ -42,7 +46,29 @@ public final class PropertyLoaderModuleConfigBuilder {
         return this;
     }
 
+    /**
+     * Add a custom file suffix to accept (e.g. "conf").
+     *
+     * @param suffix the custom file suffix
+     * @return the builder
+     */
+    public PropertyLoaderModuleConfigBuilder addCustomFileSuffix(String suffix) {
+        this.customFileSuffixes.add(suffix);
+        return this;
+    }
+
+    /**
+     * Add multiple custom file suffixes to accept.
+     *
+     * @param suffixes the custom file suffixes
+     * @return the builder
+     */
+    public PropertyLoaderModuleConfigBuilder addCustomFileSuffixes(Set<String> suffixes) {
+        this.customFileSuffixes.addAll(suffixes);
+        return this;
+    }
+
     public PropertyLoaderModuleConfig build() {
-        return new PropertyLoaderModuleConfig(parser, lexer);
+        return new PropertyLoaderModuleConfig(parser, lexer, customFileSuffixes);
     }
 }

--- a/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
+++ b/gestalt-core/src/test/java/org/github/gestalt/config/loader/PropertyLoaderTest.java
@@ -544,4 +544,75 @@ class PropertyLoaderTest {
 
         Assertions.assertFalse(result.getKey("cars").get().getIndex(3).isPresent());
     }
+
+    @Test
+    void acceptsCustomFileSuffixes() {
+        // Test that custom file suffixes can be configured
+        PropertyLoader propsLoader = new PropertyLoader();
+        
+        // By default, conf is not accepted
+        Assertions.assertFalse(propsLoader.accepts("conf"));
+        
+        // Configure custom suffixes via module config
+        Set<String> customSuffixes = new HashSet<>();
+        customSuffixes.add("conf");
+        customSuffixes.add("config");
+        
+        PropertyLoaderModuleConfig moduleConfig = new PropertyLoaderModuleConfig(
+            new MapConfigParser(), 
+            new PathLexer(), 
+            customSuffixes
+        );
+        
+        GestaltConfig gestaltConfig = Mockito.mock(GestaltConfig.class);
+        Mockito.when(gestaltConfig.getModuleConfig(PropertyLoaderModuleConfig.class)).thenReturn(moduleConfig);
+        
+        // Apply the configuration
+        propsLoader.applyConfig(gestaltConfig);
+        
+        // Now conf and config should be accepted
+        Assertions.assertTrue(propsLoader.accepts("conf"));
+        Assertions.assertTrue(propsLoader.accepts("config"));
+        
+        // But other suffixes should not be accepted
+        Assertions.assertFalse(propsLoader.accepts("yaml"));
+        
+        // The default suffixes should still be accepted
+        Assertions.assertTrue(propsLoader.accepts("properties"));
+        Assertions.assertTrue(propsLoader.accepts("props"));
+    }
+
+    @Test
+    void acceptsCustomFileSuffixesWithBuilder() {
+        // Test that custom file suffixes can be configured using the builder
+        PropertyLoader propsLoader = new PropertyLoader();
+        
+        // By default, conf is not accepted
+        Assertions.assertFalse(propsLoader.accepts("conf"));
+        
+        // Configure custom suffixes via builder
+        PropertyLoaderModuleConfig moduleConfig = PropertyLoaderModuleConfigBuilder.builder()
+            .setConfigParser(new MapConfigParser())
+            .setLexer(new PathLexer())
+            .addCustomFileSuffix("conf")
+            .addCustomFileSuffix("config")
+            .build();
+        
+        GestaltConfig gestaltConfig = Mockito.mock(GestaltConfig.class);
+        Mockito.when(gestaltConfig.getModuleConfig(PropertyLoaderModuleConfig.class)).thenReturn(moduleConfig);
+        
+        // Apply the configuration
+        propsLoader.applyConfig(gestaltConfig);
+        
+        // Now conf and config should be accepted
+        Assertions.assertTrue(propsLoader.accepts("conf"));
+        Assertions.assertTrue(propsLoader.accepts("config"));
+        
+        // But other suffixes should not be accepted
+        Assertions.assertFalse(propsLoader.accepts("yaml"));
+        
+        // The default suffixes should still be accepted
+        Assertions.assertTrue(propsLoader.accepts("properties"));
+        Assertions.assertTrue(propsLoader.accepts("props"));
+    }
 }


### PR DESCRIPTION
## Description
This PR adds support for custom file suffixes in PropertyLoader, addressing issue #253.

## Changes
- Added  field to PropertyLoader to support custom file suffixes like .conf
- Updated PropertyLoaderModuleConfig to accept custom suffixes configuration
- Updated PropertyLoaderModuleConfigBuilder with  and  methods
- Added comprehensive tests to verify custom file suffix configuration works correctly

## Usage Example
```java
PropertyLoaderModuleConfig moduleConfig = PropertyLoaderModuleConfigBuilder.builder()
    .setConfigParser(new MapConfigParser())
    .setLexer(new PathLexer())
    .addCustomFileSuffix("conf")
    .addCustomFileSuffix("config")
    .build();

GestaltConfig config = new GestaltConfig();
config.registerModuleConfig(moduleConfig);

PropertyLoader loader = new PropertyLoader();
loader.applyConfig(config);

// Now the loader accepts .conf and .config files
assertTrue(loader.accepts("conf"));
assertTrue(loader.accepts("config"));
```

## Fixes
Closes #253